### PR TITLE
Fix race condition affecting OPA-800s

### DIFF
--- a/hardware/opas/OPA-800/OPA-800.py
+++ b/hardware/opas/OPA-800/OPA-800.py
@@ -275,7 +275,6 @@ class Driver(BaseDriver):
             self.poynting_correction.get_motor_positions()
 
     def initialize(self):
-        self.hardware.destination.write(self.position.read(self.native_units), self.native_units)
         self.serial_number = -1
         self.recorded['w%d' % self.index] = [self.position, self.native_units, 1., str(self.index)]
         # motor positions


### PR DESCRIPTION
The line is already accounted for in the more general case https://github.com/wright-group/PyCMDS/blob/72784a2a3eae4b9408d68bbb082c1fbddb00d6f9/hardware/hardware.py#L192