### PR TITLE
Change default poynting cutoff factor

### DIFF
--- a/somatic/modules/poynting_tune.py
+++ b/somatic/modules/poynting_tune.py
@@ -113,7 +113,7 @@ class Worker(acquisition.Worker):
                     p = os.path.join(scan_folder, '000.data')
                     data = wt.data.from_PyCMDS(p)
                     channel = self.aqn.read('processing', 'channel')
-                    wt.tuning.workup.intensity(data, curve, channel, save_directory = scan_folder)
+                    wt.tuning.workup.intensity(data, curve, channel, save_directory = scan_folder, cutoff_factor=1e-3)
 
                     p = wt.kit.glob_handler('.curve', folder = scan_folder)[0]
                     opa_hardware.driver.curve_paths['Poynting'].write(p)


### PR DESCRIPTION
We have much better signal to noise than the default assumes, and was causing legitimate slices to be ignored.