### PR TITLE
WrightTools 3 and Attune

### DIFF
--- a/PyCMDS.py
+++ b/PyCMDS.py
@@ -286,9 +286,9 @@ class MainWindow(QtGui.QMainWindow):
         size = self.geometry() 
         self.move((screen.width()-size.width())/2, (screen.height()-size.height())/2)
         
-    def get_status(self):
+    def get_status(self, full=False):
         # called by slack
-        return self.queue_gui.get_status()
+        return self.queue_gui.get_status(full)
 
 def main():
     global MainWindow

--- a/PyCMDS.py
+++ b/PyCMDS.py
@@ -66,7 +66,7 @@ directory = os.path.abspath(os.path.dirname(__file__))
 
 # MAJOR.MINOR.PATCH (semantic versioning)
 # major version changes may break backwards compatibility
-__version__ = '0.9.0'
+__version__ = '0.10.0'
 
 # add git branch, if appropriate
 p = os.path.join(directory, '.git', 'HEAD')

--- a/PyCMDS.py
+++ b/PyCMDS.py
@@ -28,7 +28,6 @@ for folder in folders:
 
 
 import sys
-import imp
 import copy
 import glob
 import inspect

--- a/autonomic/coset.py
+++ b/autonomic/coset.py
@@ -152,7 +152,6 @@ class CoSetHW:
         label.setMargin(3)
         self.table.setCellWidget(new_row_index, 0, label)
         # path
-        _, name, _ = wt.kit.filename_parse(corr.path)
         name = pathlib.Path(corr.path).stem
         label = pw.Label(name)
         label.setMargin(3)

--- a/autonomic/coset.py
+++ b/autonomic/coset.py
@@ -97,7 +97,7 @@ class CoSetHW:
         name = pathlib.Path(corr.path).stem
         label = pw.Label(name)
         label.setMargin(3)
-        label.setToolTip(corr.path)
+        label.setToolTip(str(corr.path))
         self.table.setCellWidget(new_row_index, 1, label)
         # button
         button = pw.SetButton('REMOVE', color='stop')
@@ -207,7 +207,7 @@ class CoSetHW:
                 break  # should only be one
         # load in
         self.load_file(path)
-        ini.write(self.hardware.name, corr.setpoints.name, corr.path, with_apostrophe=True)
+        ini.write(self.hardware.name, corr.setpoints.name, str(corr.path), with_apostrophe=True)
         self.display_combobox.write(corr.setpoints.name)
 
     def on_remove_file(self, row):
@@ -281,14 +281,20 @@ class CoSetHW:
         '''
         Offsets to zero for all corrs based on current positions.
         '''
+        use = self.use_bool.read()
+        paths = []
         for i, corr in enumerate(self.corrs):
             corr.offset_to(list(corr.dependents.keys())[0], 0, self.control_position[i])
-            corr.name += " offset"
-            path = corr.save(save_directory=pathlib.Path(g.main_dir.read()) / "autonomic" / "files")
-            self.load_file(path)
-            ini.write(self.hardware.name, corr.setpoints.name, corr.path, with_apostrophe=True)
+            corr.name = f"{next(iter(corr.dependents))}_{corr.setpoints.name} offset"
+            paths.append(corr.save(save_directory=pathlib.Path(g.main_dir.read()) / "autonomic" / "files"))
+        for i in range(len(self.corrs)):
+            self.unload_file(0)
+        for path in paths:
+            corr = self.load_file(path)
+            ini.write(self.hardware.name, corr.setpoints.name, str(corr.path), with_apostrophe=True)
 
         self.launch()
+        use = self.use_bool.write(use)
         self.update_display()
 
 

--- a/autonomic/coset.py
+++ b/autonomic/coset.py
@@ -1,6 +1,7 @@
 ### import ####################################################################
 
 import os
+import pathlib
 import ast
 import collections
 
@@ -152,6 +153,7 @@ class CoSetHW:
         self.table.setCellWidget(new_row_index, 0, label)
         # path
         _, name, _ = wt.kit.filename_parse(corr.path)
+        name = pathlib.Path(corr.path).stem
         label = pw.Label(name)
         label.setMargin(3)
         label.setToolTip(corr.path)

--- a/autonomic/coset.py
+++ b/autonomic/coset.py
@@ -282,7 +282,12 @@ class CoSetHW:
         Offsets to zero for all corrs based on current positions.
         '''
         for i, corr in enumerate(self.corrs):
-            corr.offset_to(list(corr.dependents.keys())[:], 0, self.control_position[i])
+            corr.offset_to(list(corr.dependents.keys())[0], 0, self.control_position[i])
+            corr.name += " offset"
+            path = corr.save(save_directory=pathlib.Path(g.main_dir.read()) / "autonomic" / "files")
+            self.load_file(path)
+            ini.write(self.hardware.name, corr.setpoints.name, corr.path, with_apostrophe=True)
+
         self.launch()
         self.update_display()
 

--- a/devices/devices.py
+++ b/devices/devices.py
@@ -20,6 +20,7 @@ from PyQt4 import QtCore, QtGui
 import pyqtgraph as pg
 
 import WrightTools as wt
+import tidy_headers
 
 import project.project_globals as g
 import project.classes as pc
@@ -243,7 +244,7 @@ class FileAddress(QtCore.QObject):
         data_path.write(os.path.join(scan_folder, self.filename + '.data'))
         # generate file
         dictionary = headers.read(kind='data')
-        wt.kit.write_headers(data_path.read(), dictionary)
+        tidy_headers.write(data_path.read(), dictionary)
         # shots ---------------------------------------------------------------
         # TODO: this is hack
         if aqn.has_section('NI 6251'):

--- a/hardware/delays/Aerotech/Aerotech.py
+++ b/hardware/delays/Aerotech/Aerotech.py
@@ -28,11 +28,11 @@ main_dir = g.main_dir.read()
 class Driver(BaseDriver):
 
     def __init__(self, *args, **kwargs):
+        BaseDriver.__init__(self, *args, **kwargs)
         self.com_channel = kwargs.pop('port')
         kwargs['native_units'] = 'ps'
         self.index = kwargs.pop('index')
         self.native_per_mm = 6.671281903963041
-        BaseDriver.__init__(self, *args, **kwargs)
 
     def close(self):
         self.port.write('S')

--- a/hardware/delays/LTS300/LTS300.py
+++ b/hardware/delays/LTS300/LTS300.py
@@ -29,10 +29,10 @@ main_dir = g.main_dir.read()
 class Driver(BaseDriver):
 
     def __init__(self, *args, **kwargs):
+        BaseDriver.__init__(self, *args, **kwargs)
         kwargs['native_units'] = 'ps'
         self.index = kwargs.pop('index')
         self.native_per_mm = 6.671281903963041
-        BaseDriver.__init__(self, *args, **kwargs)
 
     def close(self):
         self.motor.close()

--- a/hardware/delays/MFA/MFA.py
+++ b/hardware/delays/MFA/MFA.py
@@ -83,7 +83,7 @@ class Driver(BaseDriver):
     def __init__(self, *args, **kwargs):
         super(self.__class__, self).__init__(*args, **kwargs)
         self.index = kwargs.pop('index')
-        self.native_per_mm = 6000.671281903963041
+        self.native_per_mm = 6671.281903963041
         self.axis = kwargs.pop('axis')
         self.status = pc.String(display=True)
         self.motor_limits = pc.NumberLimits(0, 25, 'mm')

--- a/hardware/delays/MFA/MFA.py
+++ b/hardware/delays/MFA/MFA.py
@@ -81,11 +81,11 @@ status_dict = {value: key for key, value in controller_states.items()}
 class Driver(BaseDriver):
 
     def __init__(self, *args, **kwargs):
-        self.index = kwargs.pop('index')
-        self.axis = kwargs.pop('axis')
-        self.native_per_mm = 6000.671281903963041
-        self.status = pc.String(display=True)
         super(self.__class__, self).__init__(*args, **kwargs)
+        self.index = kwargs.pop('index')
+        self.native_per_mm = 6000.671281903963041
+        self.axis = kwargs.pop('axis')
+        self.status = pc.String(display=True)
         self.motor_limits = pc.NumberLimits(0, 25, 'mm')
         self.motor_position.decimals = 5
         self.zero_position.decimals = 5

--- a/hardware/delays/PMC/PMC.py
+++ b/hardware/delays/PMC/PMC.py
@@ -20,9 +20,9 @@ main_dir = g.main_dir.read()
 class Driver(BaseDriver):
 
     def __init__(self, *args, **kwargs):
+        BaseDriver.__init__(self, *args, **kwargs)
         self.index = kwargs['index']
         self.native_per_mm = 6.671281903963041
-        BaseDriver.__init__(self, *args, **kwargs)
 
     def close(self):
         self.motor.close()

--- a/hardware/delays/delays.py
+++ b/hardware/delays/delays.py
@@ -2,7 +2,6 @@
 
 
 import os
-import imp
 import time
 import collections
 

--- a/hardware/delays/delays.py
+++ b/hardware/delays/delays.py
@@ -43,6 +43,7 @@ class Driver(hw.Driver):
         self.zero_position = self.hardware.zero_position
         self.zero_position.write(kwargs['zero_position'])
         self.recorded['_'.join([self.name, 'zero'])] = [self.zero_position, 'mm', 0.001, self.name[-1], True]
+        self.native_per_mm = 1
         
     def save_status(self):
         self.hardware_ini.write(self.name, 'zero_position', self.zero_position.read(self.motor_units))
@@ -68,6 +69,10 @@ class Driver(hw.Driver):
         self.recorded['d' + str(self.index)] = [self.position, self.native_units, 1., self.label.read(), False]
         self.recorded['d' + str(self.index) + '_position'] = [self.motor_position, 'mm', 1., self.label.read(), False]
         self.recorded['d' + str(self.index) + '_zero'] = [self.zero_position, 'mm', 1., self.label.read(), False] 
+
+    def set_zero(self, new_zero):
+        pass
+
 
 
 # --- gui -----------------------------------------------------------------------------------------

--- a/hardware/filters/filters.py
+++ b/hardware/filters/filters.py
@@ -2,7 +2,6 @@
 
 
 import os
-import imp
 import time
 import collections
 

--- a/hardware/opas/OPA-800/OPA-800.py
+++ b/hardware/opas/OPA-800/OPA-800.py
@@ -113,7 +113,7 @@ class AutoTune(BaseAutoTune):
             p = os.path.join(scan_folder, '000.data')
             data = wt.data.from_PyCMDS(p)
             channel = worker.aqn.read('BBO', 'channel')
-            wt.tuning.workup.intensity(data, curve, channel, save_directory=scan_folder)
+            attune.workup.intensity(data, curve, channel, save_directory=scan_folder)
             # apply new curve
             p = wt.kit.glob_handler('.curve', folder=scan_folder)[0]
             self.driver.curve_path.write(p)
@@ -146,7 +146,7 @@ class AutoTune(BaseAutoTune):
             p = os.path.join(scan_folder, '000.data')
             data = wt.data.from_PyCMDS(p)
             channel = worker.aqn.read('Mixer', 'channel')
-            wt.tuning.workup.intensity(data, curve, channel, save_directory=scan_folder)
+            attune.workup.intensity(data, curve, channel, save_directory=scan_folder)
             # apply new curve
             p = wt.kit.glob_handler('.curve', folder=scan_folder)[0]
             self.driver.curve_path.write(p)
@@ -177,7 +177,7 @@ class AutoTune(BaseAutoTune):
             p = wt.kit.glob_handler('.data', folder=scan_folder)[0]
             data = wt.data.from_PyCMDS(p)
             channel = worker.aqn.read('Test', 'channel')
-            wt.tuning.workup.tune_test(data, curve, channel, save_directory=scan_folder)
+            attune.workup.tune_test(data, curve, channel, save_directory=scan_folder)
             # apply new curve
             p = wt.kit.glob_handler('.curve', folder=scan_folder)[0]
             self.driver.curve_path.write(p)
@@ -245,7 +245,7 @@ class Driver(BaseDriver):
         '''
         when loading externally, write to curve_path object directly
         '''
-        self.curve = wt.tuning.curve.from_800_curve(self.curve_paths['Curve'].read())
+        self.curve = attune.curve.read(self.curve_paths['Curve'].read())
         return self.curve
 
     def _set_motors(self, motor_indexes, motor_destinations):

--- a/hardware/opas/OPA-800/OPA-800.py
+++ b/hardware/opas/OPA-800/OPA-800.py
@@ -92,8 +92,8 @@ class AutoTune(BaseAutoTune):
         if worker.aqn.read('BBO', 'do'):
             axes = []
             # tune points
-            points = curve.setpoints
-            units = curve.units
+            points = curve.setpoints[:]
+            units = curve.setpoints.units
             name = identity = self.driver.name
             axis = acquisition.Axis(points=points, units=units, name=name, identity=identity)
             axes.append(axis)
@@ -117,7 +117,7 @@ class AutoTune(BaseAutoTune):
             transform = list(data.axis_names)
             transform[-1] = transform[-1] + "_points"
             data.transform(*transform)
-            attune.workup.intensity(data, curve, channel, save_directory=scan_folder)
+            attune.workup.intensity(data, channel, "BBO",curve, save_directory=scan_folder)
             # apply new curve
             p = wt.kit.glob_handler('.curve', folder=scan_folder)[0]
             self.driver.curve_path.write(p)
@@ -128,8 +128,8 @@ class AutoTune(BaseAutoTune):
         if worker.aqn.read('Mixer', 'do'):
             axes = []
             # tune points
-            points = curve.setpoints
-            units = curve.units
+            points = curve.setpoints[:]
+            units = curve.setpoints.units
             name = identity = self.driver.name
             axis = acquisition.Axis(points=points, units=units, name=name, identity=identity)
             axes.append(axis)
@@ -153,7 +153,7 @@ class AutoTune(BaseAutoTune):
             transform[-1] = transform[-1] + "_points"
             data.transform(*transform)
             channel = worker.aqn.read('Mixer', 'channel')
-            attune.workup.intensity(data, curve, channel, save_directory=scan_folder)
+            attune.workup.intensity(data, channel, "Mixer", curve, save_directory=scan_folder)
             # apply new curve
             p = wt.kit.glob_handler('.curve', folder=scan_folder)[0]
             self.driver.curve_path.write(p)
@@ -164,8 +164,8 @@ class AutoTune(BaseAutoTune):
         if worker.aqn.read('Test', 'do'):
             axes = []
             # tune points
-            points = curve.setpoints
-            units = curve.units
+            points = curve.setpoints[:]
+            units = curve.setpoints.units
             name = identity = self.driver.name
             axis = acquisition.Axis(points=points, units=units, name=name, identity=identity)
             axes.append(axis)
@@ -175,7 +175,7 @@ class AutoTune(BaseAutoTune):
             width = worker.aqn.read('Test', 'width')
             npts = int(worker.aqn.read('Test', 'number'))
             points = np.linspace(-width/2., width/2., npts)
-            kwargs = {'centers': curve.setpoints}
+            kwargs = {'centers': curve.setpoints[:]}
             axis = acquisition.Axis(points, 'wn', name, identity, **kwargs)
             axes.append(axis)
             # do scan
@@ -187,7 +187,7 @@ class AutoTune(BaseAutoTune):
             transform = list(data.axis_names)
             transform[-1] = transform[-1] + "_points"
             data.transform(*transform)
-            attune.workup.tune_test(data, curve, channel, save_directory=scan_folder)
+            attune.workup.tune_test(data, channel, curve, save_directory=scan_folder)
             # apply new curve
             p = wt.kit.glob_handler('.curve', folder=scan_folder)[0]
             self.driver.curve_path.write(p)
@@ -234,7 +234,7 @@ class Driver(BaseDriver):
     def __init__(self, *args, **kwargs):
         self.motor_names = ['Grating', 'BBO', 'Mixer']
         self.auto_tune = AutoTune(self)
-        self.motors = []
+        self.motors = {}
         self.homeable = [False]
         self.curve_paths = collections.OrderedDict()
         # TODO: Determine if pico_opa needs to have interaction string combo
@@ -259,29 +259,24 @@ class Driver(BaseDriver):
         self.curve.kind = "opa800"
         return self.curve
 
-    def _set_motors(self, motor_indexes, motor_destinations):
-        for axis, dest in zip(motor_indexes, motor_destinations):
-            if axis < 3:
-                if dest >= 0 and dest <= 50:
-                    self.motors[axis].move_absolute(dest)
-                else:
-                    print('That is not a valid axis '+str(axis)+' motor positon. Nice try, bucko.')
-            else:
-                print('Unrecognized axis '+str(axis))
+    def _set_motors(self, motor_destinations):
+        for axis, dest in motor_destinations.items():
+            if dest >= 0 and dest <= 50:
+                self.motors[axis].move_absolute(dest)
 
     def _wait_until_still(self):
-        for motor in self.motors:
+        for motor in self.motors.values():
             motor.wait_until_still(method=self.get_position)
 
     def close(self):
-        for motor in self.motors:
+        for motor in self.motors.values():
             motor.close()
         BaseDriver.close(self)
 
     def get_motor_positions(self):
-        for i in range(len(self.motors)):
+        for i in self.motors:
             val = self.motors[i].current_position_mm
-            list(self.motor_positions.values())[i].write(val)
+            self.motor_positions[i].write(val)
         if self.poynting_correction:
             self.poynting_correction.get_motor_positions()
 
@@ -296,8 +291,8 @@ class Driver(BaseDriver):
             number = pc.Number(name=motor_name, initial_value=25.,
                                decimals=6, limits=motor_limits, display=True)
             self.motor_positions[motor_name] = number
-            self.motors.append(pm_motors.Motor(
-                pm_motors.identity['OPA%d %s' % (self.index, motor_name)]))
+            self.motors.update({ "motor_name", pm_motors.Motor(
+                pm_motors.identity['OPA%d %s' % (self.index, motor_name)])})
             self.recorded['w%d_%s' % (self.index, motor_name)] = [
                 number, None, 0.001, motor_name.lower()]
         # self.get_motor_positions()
@@ -309,7 +304,7 @@ class Driver(BaseDriver):
         BaseDriver.initialize(self)
 
     def is_busy(self):
-        for motor in self.motors:
+        for motor in self.motors.values():
             if not motor.is_stopped():
                 self.get_position()
                 return True

--- a/hardware/opas/OPA-800/OPA-800.py
+++ b/hardware/opas/OPA-800/OPA-800.py
@@ -92,7 +92,7 @@ class AutoTune(BaseAutoTune):
         if worker.aqn.read('BBO', 'do'):
             axes = []
             # tune points
-            points = curve.colors
+            points = curve.setpoints
             units = curve.units
             name = identity = self.driver.name
             axis = acquisition.Axis(points=points, units=units, name=name, identity=identity)
@@ -128,7 +128,7 @@ class AutoTune(BaseAutoTune):
         if worker.aqn.read('Mixer', 'do'):
             axes = []
             # tune points
-            points = curve.colors
+            points = curve.setpoints
             units = curve.units
             name = identity = self.driver.name
             axis = acquisition.Axis(points=points, units=units, name=name, identity=identity)
@@ -164,7 +164,7 @@ class AutoTune(BaseAutoTune):
         if worker.aqn.read('Test', 'do'):
             axes = []
             # tune points
-            points = curve.colors
+            points = curve.setpoints
             units = curve.units
             name = identity = self.driver.name
             axis = acquisition.Axis(points=points, units=units, name=name, identity=identity)
@@ -175,7 +175,7 @@ class AutoTune(BaseAutoTune):
             width = worker.aqn.read('Test', 'width')
             npts = int(worker.aqn.read('Test', 'number'))
             points = np.linspace(-width/2., width/2., npts)
-            kwargs = {'centers': curve.colors}
+            kwargs = {'centers': curve.setpoints}
             axis = acquisition.Axis(points, 'wn', name, identity, **kwargs)
             axes.append(axis)
             # do scan
@@ -255,7 +255,7 @@ class Driver(BaseDriver):
         '''
         when loading externally, write to curve_path object directly
         '''
-        self.curve = attune.curve.read(self.curve_paths['Curve'].read())
+        self.curve = attune.Curve.read(self.curve_paths['Curve'].read())
         self.curve.kind = "opa800"
         return self.curve
 

--- a/hardware/opas/OPA-800/OPA-800.py
+++ b/hardware/opas/OPA-800/OPA-800.py
@@ -256,6 +256,7 @@ class Driver(BaseDriver):
         when loading externally, write to curve_path object directly
         '''
         self.curve = attune.curve.read(self.curve_paths['Curve'].read())
+        self.curve.kind = "opa800"
         return self.curve
 
     def _set_motors(self, motor_indexes, motor_destinations):

--- a/hardware/opas/OPA-800/OPA-800.py
+++ b/hardware/opas/OPA-800/OPA-800.py
@@ -235,7 +235,6 @@ class Driver(BaseDriver):
         self.motor_names = ['Grating', 'BBO', 'Mixer']
         self.auto_tune = AutoTune(self)
         self.motors = {}
-        self.homeable = [False]
         self.curve_paths = collections.OrderedDict()
         # TODO: Determine if pico_opa needs to have interaction string combo
         allowed_values = ['SHS']
@@ -248,7 +247,6 @@ class Driver(BaseDriver):
         self.curve_path.updated.connect(lambda: self.load_curve())
 
         self.curve_paths['Curve'] = self.curve_path
-        print(self.curve_paths)
         self.load_curve()
 
     def _load_curve(self, interaction):

--- a/hardware/opas/OPA-800/OPA-800.py
+++ b/hardware/opas/OPA-800/OPA-800.py
@@ -114,6 +114,9 @@ class AutoTune(BaseAutoTune):
             p = os.path.join(scan_folder, '000.data')
             data = wt.data.from_PyCMDS(p)
             channel = worker.aqn.read('BBO', 'channel')
+            transform = list(data.axis_names)
+            transform[-1] = transform[-1] + "_points"
+            data.transform(*transform)
             attune.workup.intensity(data, curve, channel, save_directory=scan_folder)
             # apply new curve
             p = wt.kit.glob_handler('.curve', folder=scan_folder)[0]
@@ -146,6 +149,9 @@ class AutoTune(BaseAutoTune):
             # process
             p = os.path.join(scan_folder, '000.data')
             data = wt.data.from_PyCMDS(p)
+            transform = list(data.axis_names)
+            transform[-1] = transform[-1] + "_points"
+            data.transform(*transform)
             channel = worker.aqn.read('Mixer', 'channel')
             attune.workup.intensity(data, curve, channel, save_directory=scan_folder)
             # apply new curve
@@ -178,6 +184,9 @@ class AutoTune(BaseAutoTune):
             p = wt.kit.glob_handler('.data', folder=scan_folder)[0]
             data = wt.data.from_PyCMDS(p)
             channel = worker.aqn.read('Test', 'channel')
+            transform = list(data.axis_names)
+            transform[-1] = transform[-1] + "_points"
+            data.transform(*transform)
             attune.workup.tune_test(data, curve, channel, save_directory=scan_folder)
             # apply new curve
             p = wt.kit.glob_handler('.curve', folder=scan_folder)[0]

--- a/hardware/opas/OPA-800/OPA-800.py
+++ b/hardware/opas/OPA-800/OPA-800.py
@@ -291,7 +291,7 @@ class Driver(BaseDriver):
             number = pc.Number(name=motor_name, initial_value=25.,
                                decimals=6, limits=motor_limits, display=True)
             self.motor_positions[motor_name] = number
-            self.motors.update({ "motor_name", pm_motors.Motor(
+            self.motors.update({ motor_name: pm_motors.Motor(
                 pm_motors.identity['OPA%d %s' % (self.index, motor_name)])})
             self.recorded['w%d_%s' % (self.index, motor_name)] = [
                 number, None, 0.001, motor_name.lower()]

--- a/hardware/opas/OPA-800/OPA-800.py
+++ b/hardware/opas/OPA-800/OPA-800.py
@@ -6,6 +6,7 @@ import collections
 import numpy as np
 
 import WrightTools as wt
+import attune
 
 import project.classes as pc
 import project.widgets as pw

--- a/hardware/opas/OPA-800/OPA-800.py
+++ b/hardware/opas/OPA-800/OPA-800.py
@@ -98,12 +98,12 @@ class AutoTune(BaseAutoTune):
             axis = acquisition.Axis(points=points, units=units, name=name, identity=identity)
             axes.append(axis)
             # motor
-            name = '_'.join([self.driver.name, curve.motor_names[1]])
+            name = '_'.join([self.driver.name, "BBO"])
             identity = 'D' + name
             width = worker.aqn.read('BBO', 'width')
             npts = int(worker.aqn.read('BBO', 'number'))
             points = np.linspace(-width/2., width/2., npts)
-            motor_positions = curve.motors[1].positions
+            motor_positions = curve["BBO"].positions
             kwargs = {'centers': motor_positions}
             hardware_dict = {name: [self.driver.hardware, 'set_motor', ['BBO', 'destination']]}
             axis = acquisition.Axis(points, None, name, identity, hardware_dict, **kwargs)
@@ -134,12 +134,12 @@ class AutoTune(BaseAutoTune):
             axis = acquisition.Axis(points=points, units=units, name=name, identity=identity)
             axes.append(axis)
             # motor
-            name = '_'.join([self.driver.name, curve.motor_names[2]])
+            name = '_'.join([self.driver.name, "Mixer"])
             identity = 'D' + name
             width = worker.aqn.read('Mixer', 'width')
             npts = int(worker.aqn.read('Mixer', 'number'))
             points = np.linspace(-width/2., width/2., npts)
-            motor_positions = curve.motors[2].positions
+            motor_positions = curve["Mixer"].positions
             kwargs = {'centers': motor_positions}
             hardware_dict = {name: [self.driver.hardware, 'set_motor', ['Mixer', 'destination']]}
             axis = acquisition.Axis(points, None, name, identity, hardware_dict, **kwargs)

--- a/hardware/opas/TOPAS/TOPAS-800.py
+++ b/hardware/opas/TOPAS/TOPAS-800.py
@@ -19,7 +19,8 @@ class AutoTune(BaseAutoTune):
 class Driver(BaseDriver):
     
     def __init__(self, *args, **kwargs):
-        self.motor_names = ['Crystal', 'Amplifier', 'Grating', 'NDFG_Crystal', 'NDFG_Mirror', 'NDFG_Delay']
+        #self.motor_names = ['Crystal', 'Amplifier', 'Grating', 'NDFG_Crystal', 'NDFG_Mirror', 'NDFG_Delay']
+        self.motor_names = ['0', '1', '2', '3', '4', '5']
         self.curve_indices = {'Base': 1, 'Mixer 3': 4}
         self.kind = "TOPAS-800"
         BaseDriver.__init__(self, *args, **kwargs)

--- a/hardware/opas/TOPAS/TOPAS.py
+++ b/hardware/opas/TOPAS/TOPAS.py
@@ -330,9 +330,11 @@ class Driver(BaseDriver):
         self.load_curve(update = False)
 
     def _get_motor_index(self, name):
-        for m in motor_names:
-            if m in c.dependents:
-                return c[m].index
+        c = self.curve
+        while c is not None:
+            if name in c.dependents:
+                return c[name].index
+            c = c.subcurve
         raise KeyError(name)
 
     def _home_motors(self, motor_names):

--- a/hardware/opas/TOPAS/TOPAS.py
+++ b/hardware/opas/TOPAS/TOPAS.py
@@ -172,7 +172,7 @@ class AutoTune(BaseAutoTune):
             curve = self.opa.curve
             channel = worker.aqn.read('BBO', 'channel')
             old_curve_filepath = curve_path.read()
-            wt.tuning.workup.intensity(data, curve, channel, save_directory=scan_folder)
+            attune.workup.intensity(data, curve, channel, save_directory=scan_folder)
             # apply new curve
             p = wt.kit.glob_handler('.curve', folder=scan_folder)[0]
             self.opa.curve_path.write(p)
@@ -207,7 +207,7 @@ class AutoTune(BaseAutoTune):
             curve = self.opa.curve
             channel = worker.aqn.read('Mixer', 'channel')
             old_curve_filepath = self.opa.curve_path.read()
-            wt.tuning.workup.intensity(data, curve, channel, save_directory=scan_folder)
+            attune.workup.intensity(data, curve, channel, save_directory=scan_folder)
             # apply new curve
             p = wt.kit.glob_handler('.curve', folder=scan_folder)[0]
             self.opa.curve_path.write(p)
@@ -239,7 +239,7 @@ class AutoTune(BaseAutoTune):
             data = wt.data.from_PyCMDS(p)
             curve = self.opa.curve
             channel = worker.aqn.read('Test', 'channel')
-            wt.tuning.workup.tune_test(data, curve, channel, save_directory=scan_folder)
+            attune.workup.tune_test(data, curve, channel, save_directory=scan_folder)
             # apply new curve
             p = wt.kit.glob_handler('.curve', folder=scan_folder)[0]
             self.opa.curve_path.write(p)
@@ -421,7 +421,7 @@ class Driver(BaseDriver):
         need = [x for x in range(4) if x+1 not in used]        
         for i in need:
             crv_paths.insert(i,None)
-        self.curve = wt.tuning.curve.from_TOPAS_crvs(crv_paths, self.kind, interaction)
+        self.curve = attune.curve.topas.read(crv_paths, self.kind, interaction)
         return self.curve
        
     def _set_motors(self, motor_indexes, motor_destinations):

--- a/hardware/opas/TOPAS/TOPAS.py
+++ b/hardware/opas/TOPAS/TOPAS.py
@@ -12,6 +12,7 @@ import ctypes
 from ctypes import *
 
 import WrightTools as wt
+import attune
 
 import project
 import project.classes as pc
@@ -22,7 +23,7 @@ from hardware.opas.opas import Driver as BaseDriver
 from hardware.opas.opas import GUI as BaseGUI
 from hardware.opas.opas import AutoTune as BaseAutoTune
 from hardware.opas.TOPAS.TOPAS_API import TOPAS_API
-from WrightTools.tuning.curve import TOPAS_interaction_by_kind
+from attune.curve.topas import TOPAS_interaction_by_kind
                                  
 # --- define --------------------------------------------------------------------------------------
 

--- a/hardware/opas/TOPAS/TOPAS.py
+++ b/hardware/opas/TOPAS/TOPAS.py
@@ -173,6 +173,9 @@ class AutoTune(BaseAutoTune):
             curve = self.opa.curve
             channel = worker.aqn.read('BBO', 'channel')
             old_curve_filepath = curve_path.read()
+            transform = list(data.axis_names)
+            transform[-1] = transform[-1] + "_points"
+            data.transform(*transform)
             attune.workup.intensity(data, curve, channel, save_directory=scan_folder)
             # apply new curve
             p = wt.kit.glob_handler('.curve', folder=scan_folder)[0]
@@ -208,6 +211,9 @@ class AutoTune(BaseAutoTune):
             curve = self.opa.curve
             channel = worker.aqn.read('Mixer', 'channel')
             old_curve_filepath = self.opa.curve_path.read()
+            transform = list(data.axis_names)
+            transform[-1] = transform[-1] + "_points"
+            data.transform(*transform)
             attune.workup.intensity(data, curve, channel, save_directory=scan_folder)
             # apply new curve
             p = wt.kit.glob_handler('.curve', folder=scan_folder)[0]
@@ -240,6 +246,9 @@ class AutoTune(BaseAutoTune):
             data = wt.data.from_PyCMDS(p)
             curve = self.opa.curve
             channel = worker.aqn.read('Test', 'channel')
+            transform = list(data.axis_names)
+            transform[-1] = transform[-1] + "_points"
+            data.transform(*transform)
             attune.workup.tune_test(data, curve, channel, save_directory=scan_folder)
             # apply new curve
             p = wt.kit.glob_handler('.curve', folder=scan_folder)[0]

--- a/hardware/opas/TOPAS/TOPAS.py
+++ b/hardware/opas/TOPAS/TOPAS.py
@@ -23,7 +23,7 @@ from hardware.opas.opas import Driver as BaseDriver
 from hardware.opas.opas import GUI as BaseGUI
 from hardware.opas.opas import AutoTune as BaseAutoTune
 from hardware.opas.TOPAS.TOPAS_API import TOPAS_API
-from attune.curve.topas import TOPAS_interaction_by_kind
+from attune.curve._topas import TOPAS_interaction_by_kind
                                  
 # --- define --------------------------------------------------------------------------------------
 
@@ -422,7 +422,7 @@ class Driver(BaseDriver):
         need = [x for x in range(4) if x+1 not in used]        
         for i in need:
             crv_paths.insert(i,None)
-        self.curve = attune.curve.topas.read(crv_paths, self.kind, interaction)
+        self.curve = attune.curve.read_topas(crv_paths, self.kind, interaction)
         return self.curve
        
     def _set_motors(self, motor_indexes, motor_destinations):

--- a/hardware/opas/TOPAS/TOPAS.py
+++ b/hardware/opas/TOPAS/TOPAS.py
@@ -317,9 +317,10 @@ class Driver(BaseDriver):
             curve_filepath.updated.connect(self.load_curve)
             self.curve_paths[curve_type] = curve_filepath
         # interaction string
-        paths.pop("Poynting Curve", None)
-        paths = paths.values()
-        all_crvs = attune.TopasCuve.read_all(paths)
+        paths = self.curve_paths.copy()
+        paths.pop("Poynting", None)
+        paths = [v.read() for v in paths.values()]
+        all_crvs = attune.TopasCurve.read_all(paths)
         allowed_values = list(all_crvs.keys())
         self.interaction_string_combo = pc.Combo(allowed_values=allowed_values)
         current_value = self.ini.read('OPA%i'%self.index, 'current interaction string')

--- a/hardware/opas/TOPAS/TOPAS.py
+++ b/hardware/opas/TOPAS/TOPAS.py
@@ -330,10 +330,21 @@ class Driver(BaseDriver):
         self.load_curve(update = False)
 
     def _get_motor_index(self, name):
-        return 0
+        for m in motor_names:
+            if m in c.dependents:
+                return c[m].index
+        raise KeyError(name)
 
-    def _home_motors(self, motor_indexes):
-        motor_indexes = list(motor_indexes)
+    def _home_motors(self, motor_names):
+        motor_indexes = []
+        c = self.curve
+        while len(motor_names):
+            for m in motor_names:
+                if m in c.dependents:
+                    motor_indexes.append(c[m].index)
+                    motor_names.pop(name)
+            c = c.subcurve
+
         section = 'OPA' + str(self.index)
         # close shutter
         if self.has_shutter:
@@ -430,8 +441,8 @@ class Driver(BaseDriver):
         return self.curve
        
     def _set_motors(self, motor_destinations):
-        for motor_name, destination in motor_destinations.items:
-            motor_index = self.get_motor_index(motor_name)
+        for motor_name, destination in motor_destinations.items():
+            motor_index = self._get_motor_index(motor_name)
             error, destination_steps = self.api.convert_position_to_steps(motor_index, destination)
             self.api.start_motor_motion(motor_index, destination_steps)
 

--- a/hardware/opas/TOPAS/TOPAS.py
+++ b/hardware/opas/TOPAS/TOPAS.py
@@ -149,7 +149,7 @@ class AutoTune(BaseAutoTune):
         if worker.aqn.read('BBO', 'do'):
             axes = []
             # tune points
-            points = curve.colors
+            points = curve.setpoints
             units = curve.units
             name = identity = self.opa.hardware.name
             axis = acquisition.Axis(points=points, units=units, name=name, identity=identity)
@@ -187,7 +187,7 @@ class AutoTune(BaseAutoTune):
         if worker.aqn.read('Mixer', 'do'):
             axes = []
             # tune points
-            points = curve.colors
+            points = curve.setpoints
             units = curve.units
             name = identity = self.opa.hardware.name
             axis = acquisition.Axis(points=points, units=units, name=name, identity=identity)
@@ -225,7 +225,7 @@ class AutoTune(BaseAutoTune):
         if worker.aqn.read('Test', 'do'):
             axes = []
             # tune points
-            points = curve.colors
+            points = curve.setpoints
             units = curve.units
             name = identity = self.opa.hardware.name
             axis = acquisition.Axis(points=points, units=units, name=name, identity=identity)
@@ -236,7 +236,7 @@ class AutoTune(BaseAutoTune):
             width = worker.aqn.read('Test', 'width') 
             npts = int(worker.aqn.read('Test', 'number'))
             points = np.linspace(-width/2., width/2., npts)
-            kwargs = {'centers': curve.colors}
+            kwargs = {'centers': curve.setpoints}
             axis = acquisition.Axis(points, 'wn', name, identity, **kwargs)
             axes.append(axis)
             # do scan
@@ -431,7 +431,7 @@ class Driver(BaseDriver):
         need = [x for x in range(4) if x+1 not in used]        
         for i in need:
             crv_paths.insert(i,None)
-        self.curve = attune.curve.read_topas(crv_paths, self.kind, interaction)
+        self.curve = attune.TopasCurve(crv_paths, self.kind, interaction)
         return self.curve
        
     def _set_motors(self, motor_indexes, motor_destinations):

--- a/hardware/opas/opas.py
+++ b/hardware/opas/opas.py
@@ -193,6 +193,7 @@ class Driver(hw.Driver):
         if self.poynting_correction:
             p = self.curve_paths['Poynting'].read()
             self.curve = attune.curve.read(p, subcurve=curve)
+            self.curve.kind = "poynting"
             self.hardware_ini.write(self.name, 'poynting_curve_path', p)
         self.curve.convert(self.native_units)
         # update limits

--- a/hardware/opas/opas.py
+++ b/hardware/opas/opas.py
@@ -140,7 +140,7 @@ class Driver(hw.Driver):
         pass
 
     def home_all(self, inputs=[]):
-        names = [i for i in self.motor_names if self.homeable.get(i)) ]
+        names = [i for i in self.motor_names if self.homeable.get(i) ]
         if self.poynting_correction:
             self.poynting_correction.home()
             for n in self.poynting_correction.motor_names:

--- a/hardware/opas/opas.py
+++ b/hardware/opas/opas.py
@@ -233,9 +233,9 @@ class Driver(hw.Driver):
         # poynting
         if self.poynting_correction:
             for _ in range(2):
-                name = motor_names.pop(-1)
-                destination = motor_destinations.pop(-1)
-                self.poynting_correction.set_motor(name, destination)
+                self.poynting_correction.set_position(destination)
+                motor_destinations.pop("Phi", None)
+                motor_destinations.pop("Theta", None)
         # OPA
         self._set_motors(motor_destinations)
         # finish

--- a/hardware/opas/opas.py
+++ b/hardware/opas/opas.py
@@ -380,7 +380,7 @@ class GUI(hw.GUI):
         # yi
         self.plot_motor.set_allowed_values(self.driver.curve.dependent_names)  # can be done on initialization?
         motor_name = self.plot_motor.read()
-        yi = self.driver.curve[motor_name](xi, units)
+        yi = self.driver.curve(xi, units)[motor_name]
         self.plot_widget.set_labels(xlabel=units, ylabel=motor_name)
         self.plot_curve.clear()
         self.plot_curve.setData(xi, yi)

--- a/hardware/opas/opas.py
+++ b/hardware/opas/opas.py
@@ -103,13 +103,13 @@ class Driver(hw.Driver):
             colors = np.linspace(400, 10000, 17)
             units = 'nm'
             motors = []
-            motors.append(wt.tuning.curve.Motor(((colors-500)/1e4)**2, 'Delay'))
-            motors.append(wt.tuning.curve.Motor(-(colors-90)**0.25, 'Crystal'))
-            motors.append(wt.tuning.curve.Motor((colors-30)**0.25, 'Mixer'))
+            motors.append(attune.curve.Motor(((colors-500)/1e4)**2, 'Delay'))
+            motors.append(attune.curve.Motor(-(colors-90)**0.25, 'Crystal'))
+            motors.append(attune.curve.Motor((colors-30)**0.25, 'Mixer'))
             name = 'curve'
             interaction = 'sig'
             kind = 'Virtual'
-            self.curve = wt.tuning.curve.Curve(colors, units, motors, name, interaction, kind)
+            self.curve = attune.curve.Curve(colors, units, motors, name, interaction, kind)
             self.curve.convert(self.native_units)
         else:
             raise NotImplementedError
@@ -191,7 +191,7 @@ class Driver(hw.Driver):
         curve = self._load_curve(interaction)
         if self.poynting_correction:
             p = self.curve_paths['Poynting'].read()
-            self.curve = wt.tuning.curve.from_poynting_curve(p, subcurve=curve)
+            self.curve = attune.curve.read(p, subcurve=curve)
             self.hardware_ini.write(self.name, 'poynting_curve_path', p)
         self.curve.convert(self.native_units)
         # update limits

--- a/hardware/opas/opas.py
+++ b/hardware/opas/opas.py
@@ -11,6 +11,7 @@ import numpy as np
 from PyQt4 import QtGui
 
 import WrightTools as wt
+import attune
 
 import project.project_globals as g
 import project.widgets as pw
@@ -319,7 +320,6 @@ class GUI(hw.GUI):
         self.plot_motor.updated.connect(self.update_plot)
         input_table.add('Motor', self.plot_motor)
         allowed_values = list(wt.units.energy.keys())
-        allowed_values.remove('kind')
         self.plot_units = pc.Combo(initial_value=self.driver.native_units, allowed_values=allowed_values)
         self.plot_units.updated.connect(self.update_plot)
         input_table.add('Units', self.plot_units)

--- a/hardware/spectrometers/spectrometers.py
+++ b/hardware/spectrometers/spectrometers.py
@@ -2,7 +2,6 @@
 
 
 import os
-import imp
 import time
 import collections
 

--- a/project/classes.py
+++ b/project/classes.py
@@ -476,10 +476,10 @@ class Number(PyCMDS_Object):
         # units
         self.units = units
         self.units_kind = None
-        for dic in wt_units.dicts:
+        for kind, dic in wt_units.dicts.items():
             if self.units in dic.keys():
                 self.units_dic = dic
-                self.units_kind = dic['kind']
+                self.units_kind = kind
         # limits
         self.limits = limits
         if self.limits is None:
@@ -594,7 +594,6 @@ class Number(PyCMDS_Object):
         self.units_widget = units_combo_widget
         # add items
         unit_types = list(self.units_dic.keys())
-        unit_types.remove('kind')
         self.units_widget.addItems(unit_types)
         # set current item
         self.units_widget.setCurrentIndex(unit_types.index(self.units))

--- a/project/classes.py
+++ b/project/classes.py
@@ -565,7 +565,6 @@ class Number(PyCMDS_Object):
 
     def set_widget(self):
         # special value text is displayed when widget is at minimum
-        print(self.value.read(), "SET_WIDGGET")
         if np.isnan(self.value.read()):
             self.widget.setSpecialValueText('nan')
             self.widget.setValue(self.widget.minimum())

--- a/project/classes.py
+++ b/project/classes.py
@@ -476,7 +476,7 @@ class Number(PyCMDS_Object):
         # units
         self.units = units
         self.units_kind = None
-        for dic in wt_units.unit_dicts:
+        for dic in wt_units.dicts:
             if self.units in dic.keys():
                 self.units_dic = dic
                 self.units_kind = dic['kind']

--- a/project/classes.py
+++ b/project/classes.py
@@ -565,6 +565,7 @@ class Number(PyCMDS_Object):
 
     def set_widget(self):
         # special value text is displayed when widget is at minimum
+        print(self.value.read(), "SET_WIDGGET")
         if np.isnan(self.value.read()):
             self.widget.setSpecialValueText('nan')
             self.widget.setValue(self.widget.minimum())

--- a/project/google_drive/_google_drive.py
+++ b/project/google_drive/_google_drive.py
@@ -1,0 +1,361 @@
+"""Interact with google drive using the pydrive package."""
+
+
+# --- import --------------------------------------------------------------------------------------
+
+
+import os
+import time
+import datetime
+import tempfile
+import appdirs
+from glob import glob
+
+
+# --- define --------------------------------------------------------------------------------------
+
+
+directory = os.path.dirname(os.path.abspath(__file__))
+
+
+# --- helper methods ------------------------------------------------------------------------------
+
+
+def id_to_url(driveid):
+    """Generate a url from a Google Drive id.
+
+    Parameters
+    ----------
+    id : string
+        ID.
+
+    Returns
+    -------
+    string
+        url.
+    """
+    return 'https://drive.google.com/open?id=' + driveid
+
+
+# --- drive class ---------------------------------------------------------------------------------
+
+
+class Drive:
+    """Google Drive class."""
+
+    def __init__(self, account_id='default'):
+        """init."""
+        # Define the temp directory and file name format
+        configDir = appdirs.user_data_dir('PyCMDS', 'WrightGroup')
+        if not os.path.isdir(configDir):
+            os.makedirs(configDir)
+        prefix = 'google-drive-'
+        suffix = '-' + account_id + '.txt'
+        # Check for existing file
+        lis = glob(os.path.join(configDir, prefix + "*" + suffix))
+        self.mycreds_path = ''
+        if len(lis) > 0:
+            for f in lis:
+                # Check that for read and write access (or is bitwise, checking both)
+                # Note this check is probably not needed with appdirs, but is not
+                #     harmful and provides additional insurance against crashes.
+                if os.access(f, os.W_OK | os.R_OK):
+                    self.mycreds_path = f
+                    break
+        # Make a new file if one does not exist with sufficent permissions
+        if self.mycreds_path == '':
+            self.mycreds_path = tempfile.mkstemp(prefix=prefix,
+                                                 suffix=suffix,
+                                                 text=True,
+                                                 dir=configDir)[1]
+        self._authenticate()
+
+    def _authenticate(self):
+        """Authenticate the user via a web browser.
+
+        This function, once run, will open up a login window in a web browser.
+        The user must then athenticate via email and password to authorize the
+        API for usage with that particular account. Note that 'mycreds.txt' may
+        just be an empty text file. This function will create the correct
+        dictionary structure in the file upon completion.
+        """
+        # This function requires a Client_secrets.json file to be in the
+        # working directory.
+        old_cwd = os.getcwd()
+        os.chdir(directory)
+        # import
+        from pydrive.auth import GoogleAuth
+        from pydrive.drive import GoogleDrive
+        # load
+        self.gauth = GoogleAuth()
+        self.gauth.LoadCredentialsFile(self.mycreds_path)
+        if self.gauth.credentials is None:
+            # authenticate if credentials are not found
+            self.gauth.LocalWebserverAuth()
+        elif self.gauth.access_token_expired:
+            # refresh credentials if they are expired
+            self.gauth.Refresh()
+        else:
+            # initialize the saved credentials
+            self.gauth.Authorize()
+        # finish
+        self.gauth.SaveCredentialsFile(self.mycreds_path)
+        self.api = GoogleDrive(self.gauth)
+        os.chdir(old_cwd)
+
+    def _upload_file(self, filepath, parentid, overwrite=False,
+                     delete_local=False, verbose=True):
+        """Upload file.
+
+        Parameters
+        ----------
+        filepath : string
+            Filepath.
+        parentid : string
+            Parent ID.
+        overwrite : boolean (optional)
+            Toggle remote overwrite. Default is False.
+        delete_local : boolean (optional).
+            Toggle local deletion after upload. Default is False.
+        verbose : boolean (optional)
+            Toggle talkback. Default is True.
+        """
+        self._authenticate()
+        title = filepath.split(os.path.sep)[-1]
+        # check if remote file already exists
+        q = {'q': "'{}' in parents and trashed=false".format(parentid)}
+        fs = self.api.ListFile(q).GetList()
+        f = None
+        for fi in fs:
+            # dont want to look at folders
+            if 'folder' in fi['mimeType']:
+                continue
+            if fi['title'] == title:
+                print(title, 'found in upload file')
+                f = fi
+        if f is not None:
+            remove = False
+            statinfo = os.stat(filepath)
+            # filesize different
+            if not int(statinfo.st_size) == int(f['fileSize']):
+                remove = True
+            # modified since creation
+            remote_stamp = f['modifiedDate'].split('.')[0]  # UTC
+            remote_stamp = time.mktime(datetime.datetime.strptime(
+                remote_stamp, '%Y-%m-%dT%H:%M:%S').timetuple())
+            local_stamp = os.path.getmtime(filepath)  # local
+            local_stamp += time.timezone  # UTC
+            if local_stamp > remote_stamp:
+                remove = True
+            # overwrite toggle
+            if overwrite:
+                remove = True
+            # remove
+            if remove:
+                f.Trash()
+                f = None
+        # upload
+        if f is None:
+            f = self.api.CreateFile({'title': title,
+                                     'parents': [{"id": parentid}]})
+            f.SetContentFile(filepath)
+            f.Upload()
+            f.content.close()
+            if verbose:
+                print('file uploaded from {}'.format(filepath))
+        # delete local
+        if delete_local:
+            os.remove(filepath)
+        # finish
+        return f['id']
+
+    def create_folder(self, name, parentid):
+        """Create a new folder in Google Drive.
+
+        Attributes
+        ----------
+        name : string or list of string
+            Name of new folder to be created or list of new folders and
+            subfolders.
+        parentID : string
+            Google Drive ID of folder that is to be the parent of new folder.
+
+        Returns
+        -------
+        string
+            The unique Google Drive ID of the bottom-most newly created folder.
+        """
+        import time
+        t = time.time()
+        self._authenticate()
+        print(time.time() - t, "Authenticate")
+        t = time.time()
+        # clean inputs
+        if isinstance(name, str):
+            name = [name]
+        # create
+        parent = parentid
+        for n in name:
+            # check if folder with that name already exists
+            q = {
+                'q': "'{}' in parents and trashed=false and mimeType contains \'folder\'".format(
+                    parent)}
+            fs = self.api.ListFile(q).GetList()
+            found = False
+            for f in fs:
+                if f['title'] == n:
+                    found = True
+                    parent = f['id']
+                    continue
+            if found:
+                continue
+            # if no folder was found, create one
+            f = self.api.CreateFile({'title': n,
+                                     "parents": [{"id": parent}],
+                                     "mimeType": "application/vnd.google-apps.folder"})
+            f.Upload()
+            parent = f['id']
+            print(time.time() - t, "created", n)
+            t = time.time()
+        return parent
+
+    def download(self, fileid, directory='cwd', overwrite=False, verbose=True):
+        """Recursively download from Google Drive into a local directory.
+
+        By default, will not re-download if file passes following checks:
+
+        1. same size as remote file
+
+        2. local file last modified after remote file
+
+        Parameters
+        ----------
+        fileid : str
+            Google drive id for file or folder.
+        directory : str (optional)
+            Local directory to save content into. By default saves to cwd.
+        overwrite : bool (optional)
+            Toggle forcing file overwrites. Default is False.
+        verbose : bool (optional)s
+            Toggle talkback. Default is True.
+
+        Returns
+        -------
+        pydrive.files.GoogleDriveFile
+        """
+        self._authenticate()
+        # get directory
+        if directory == 'cwd':
+            directory = os.getcwd()
+        # get file object
+        f = self.api.CreateFile({'id': fileid})
+        f_path = os.path.join(directory, f['title'])
+        if f['mimeType'].split('.')[-1] == 'folder':  # folder
+            # create folder
+            if not os.path.isdir(f_path):
+                os.mkdir(f_path)
+            # fill contents
+            for child_id in self.list_folder(fileid):
+                self.download(child_id, directory=f_path)
+        else:  # single file
+            # check if file exists
+            if os.path.isfile(f_path):
+                remove = False
+                statinfo = os.stat(f_path)
+                # filesize different
+                if not int(statinfo.st_size) == int(f['fileSize']):
+                    remove = True
+                # modified since creation
+                remote_stamp = f['modifiedDate'].split('.')[0]  # UTC
+                remote_stamp = time.mktime(datetime.datetime.strptime(
+                    remote_stamp, '%Y-%m-%dT%H:%M:%S').timetuple())
+                local_stamp = os.path.getmtime(f_path)  # local
+                local_stamp += time.timezone  # UTC
+                if local_stamp < remote_stamp:
+                    remove = True
+                # overwrite toggle
+                if overwrite:
+                    remove = True
+                # remove
+                if remove:
+                    os.remove(f_path)
+                else:
+                    return f
+            # download
+            f.GetContentFile(f_path)
+            if verbose:
+                print('file downloaded to {}'.format(f_path))
+            # finish
+            return f
+
+    def list_folder(self, folderid):
+        """List contents of a remote folder.
+
+        Parameters
+        ----------
+        folderid : string
+            Folder ID.
+
+        Returns
+        -------
+        list of strings
+            List of contained IDs.
+        """
+        # adapted from https://github.com/googledrive/PyDrive/issues/37
+        # folder_id: GoogleDriveFile['id']
+        self._authenticate()
+        q = {'q': "'{}' in parents and trashed=false".format(folderid)}
+        raw_sub_contents = self.api.ListFile(q).GetList()
+        return [i['id'] for i in raw_sub_contents]
+
+    def upload(self, path, parentid, overwrite=False, delete_local=False,
+               verbose=True):
+        """Upload local file(s) to Google Drive.
+
+        Parameters
+        ----------
+        path : str
+            Path to local file or folder.
+        parentid : str
+            Google Drive ID of remote folder.
+        overwrite : bool (optional)
+            Toggle forcing overwrite of remote files. Default is False.
+        delete_local : bool (optional)
+            Toggle deleting local files and folders once uploaded. Default is
+            False.
+        verbose : bool (optional)
+            Toggle talkback. Default is True.
+
+        Returns
+        -------
+        driveid : str
+            Google Drive ID of folder or file uploaded
+        """
+        self._authenticate()
+        if os.path.isfile(path):
+            return self._upload_file(path, parentid, overwrite=overwrite,
+                                     delete_local=delete_local,
+                                     verbose=verbose)
+        elif os.path.isdir(path):
+            top_path_length = len(path.split(os.path.sep))
+            for tup in os.walk(path, topdown=False):
+                self._authenticate()
+                folder_path, _, file_names = tup
+                print(folder_path)
+                # create folder on google drive
+                name = folder_path.split(os.path.sep)[top_path_length - 1:]
+                folderid = self.create_folder(name, parentid)
+                # upload files
+                for file_name in file_names:
+                    p = os.path.join(folder_path, file_name)
+                    self._upload_file(p, folderid, overwrite=overwrite,
+                                      delete_local=delete_local,
+                                      verbose=verbose)
+                # remove folder
+                if delete_local:
+                    os.rmdir(folder_path)
+            # finish
+            return folderid
+        else:
+            raise Exception('path {0} not valid in Drive.upload'.format(path))
+

--- a/project/google_drive/google_drive.py
+++ b/project/google_drive/google_drive.py
@@ -14,7 +14,7 @@ from distutils.dir_util import copy_tree
 
 from PyQt4 import QtGui, QtCore
 
-import WrightTools as wt
+from . import _google_drive
 
 import project.classes as pc
 import project.logging_handler as logging_handler
@@ -53,7 +53,7 @@ class Address(QtCore.QObject):
         QtCore.QObject.__init__(self)
         self.busy = busy
         self.enqueued = enqueued
-        self.drive = wt.google_drive.Drive()
+        self.drive = _google_drive.Drive()
         self.system_name = system_name
         self.name = 'drive'
 
@@ -146,7 +146,7 @@ class Control:
         # connect
         g.shutdown.add_method(self.close)
         # own google drive method for quick operations
-        self.drive = wt.google_drive.Drive()
+        self.drive = _google_drive.Drive()
         # session path variables
         self.data_folder = os.path.abspath(os.path.join(g.main_dir.read(), 'data'))
 
@@ -162,7 +162,7 @@ class Control:
         relative_path = os.path.relpath(os.path.abspath(path), self.data_folder)
         folder_names = [self.system_name] + relative_path.split(os.sep)
         folderid = self.drive.create_folder(folder_names, PyCMDS_data_ID)
-        folder_url = wt.google_drive.id_to_url(folderid)
+        folder_url = _google_drive.id_to_url(folderid)
         return folder_url
         
     def upload_scan(self, folder_path, representative_image_path=None):
@@ -170,7 +170,7 @@ class Control:
         folder_names = [self.system_name, queue_folder_name, acquisition_folder_name, scan_folder_name]  
         # create folder on google drive
         folderid = self.drive.create_folder(folder_names, PyCMDS_data_ID)
-        folder_url = wt.google_drive.id_to_url(folderid)
+        folder_url = _google_drive.id_to_url(folderid)
         # upload representative image
         if representative_image_path is not None:
             imageid = self.drive.upload(representative_image_path, folderid)

--- a/project/slack/bots.py
+++ b/project/slack/bots.py
@@ -61,7 +61,7 @@ class PyCMDS_bot(object):
             if 'type' in i:
                 if i['type']=='message':
                     pm = i["channel"].startswith('D')
-                    if i["text"].startswith('<@U0EALA010>'):
+                    if i.get("text", "").startswith('<@U0EALA010>'):
                         i["text"] = i["text"].split('>',1)[1]
                         mess.append(i)
                     elif pm:

--- a/project/slack/slack.py
+++ b/project/slack/slack.py
@@ -197,10 +197,12 @@ class Control:
 
     def screenshot(self, channel):
         p = QtGui.QPixmap.grabWindow(g.main_window.read().winId())
-        with tempfile.NamedTemporaryFile(suffix=".png") as tf:
-            p.save(tf.name, "png")
-            self.upload_file(tf.name, ":camera:", channel=channel)
-            time.sleep(1)
+        tf = tempfile.mkstemp()
+        p.save(tf[1], "png")
+        self.upload_file(tf[1], ":camera:", channel=channel)
+        time.sleep(1)
+        os.unlink(tf[1])
+        
 
     def log(self, text, channel):
         log_filepath = logging_handler.filepath

--- a/project/slack/slack.py
+++ b/project/slack/slack.py
@@ -4,6 +4,7 @@
 import os
 import sys
 import time
+import tempfile
 import glob
 import datetime
 
@@ -166,7 +167,40 @@ class Control:
         print(i)
 
     def interrupt(self, text, channel):
-        self.send_message(':confounded: sorry, that feature hasn\'t been implemented')        
+        subcommand = text.strip().upper()
+        if subcommand == "":
+            subcommand = "PAUSE"
+        messages = {
+                "PAUSE": ":double_vertical_bar: Queue Paused, use `interrupt resume` to continue",
+                "RESUME": ":arrow_forward: Queue resumed",
+                "STOP": ":octagonal_sign: Queue stopped, use `run` to continue with next item",
+                "SKIP": ":black_right_pointing_double_triangle_with_vertical_bar: Item skipped, continuing queue",
+            }
+        message = messages.get(subcommand, ":confounded: I do not understand the command")
+        if subcommand == "PAUSE":
+            g.main_window.read().queue_gui.queue.status.pause.write(True)
+        elif subcommand in messages.keys():
+            if g.main_window.read().queue_gui.queue.status.going.read():
+                g.main_window.read().queue_gui.queue.interrupt(option=subcommand)
+            elif subcommand == "STOP":
+                g.main_window.read().queue_gui.queue.status.go.write(False)
+        self.send_message(message)
+        g.main_window.read().queue_gui.update_ui()
+
+    def run_queue(self):
+        g.main_window.read().queue_gui.queue.status.go.write(True)
+        try:
+            g.main_window.read().queue_gui.queue.run()
+        except IndexError:  # Queue full
+            pass
+        g.main_window.read().queue_gui.update_ui()
+
+    def screenshot(self, channel):
+        p = QtGui.QPixmap.grabWindow(g.main_window.read().winId())
+        with tempfile.NamedTemporaryFile(suffix=".png") as tf:
+            p.save(tf.name, "png")
+            self.upload_file(tf.name, ":camera:", channel=channel)
+            time.sleep(1)
 
     def log(self, text, channel):
         log_filepath = logging_handler.filepath
@@ -280,7 +314,15 @@ class Control:
             elif 'append' in text.lower():
                 self.append(text, channel)
             elif 'interrupt' in text.lower():
+                try:
+                    text = text.split(' ', 1)[1]
+                except IndexError:
+                    text = ""
                 self.interrupt(text, channel)
+            elif 'run' in text.lower():
+                self.run_queue()
+            elif 'screenshot' in text.lower():
+                self.screenshot(channel)
             elif 'help' in text.lower():
                 self.send_help(channel)
             else:
@@ -291,12 +333,14 @@ class Control:
 
     def send_help(self, channel):
         command_fields = []
-        command_fields.append(self.make_field('status', 'Get the current status of PyCMDS.'))
-        command_fields.append(self.make_field('get i', 'Get more information about the ith item in the queue.'))
-        command_fields.append(self.make_field('remove i', 'Remove the ith item from the queue.'))
-        command_fields.append(self.make_field('move i to j', 'Move item i to position j. All other items retain their order.'))
-        command_fields.append(self.make_field('append [name] [info]', 'Append a file to the queue. Must be made as a comment of an attached file.'))
-        command_fields.append(self.make_field('interrupt', 'Interrupt the queue.'))
+        command_fields.append(self.make_field('status [--full]', 'Get the current status of PyCMDS.'))
+        #command_fields.append(self.make_field('remove i', 'Remove the ith item from the queue.'))
+        #command_fields.append(self.make_field('move i to j', 'Move item i to position j. All other items retain their order.'))
+        #command_fields.append(self.make_field('append [name] [info]', 'Append a file to the queue. Must be made as a comment of an attached file.'))
+        command_fields.append(self.make_field('run', 'Run the queue.'))
+        command_fields.append(self.make_field('interrupt [pause|resume|skip|stop]', 'Interrupt the queue or resume from pause. Default is pause.'))
+        command_fields.append(self.make_field('screenshot', 'Take a screenshot of the current window and post to slack.'))
+        command_fields.append(self.make_field('help', 'Show this help message.'))
         attachment = self.make_attachment('', fields=command_fields)
         self.send_message(':robot_face: here are my commands', channel, [attachment])
 
@@ -304,7 +348,7 @@ class Control:
         self.q.push('send_message', [text, channel, attachments])
         
     def status(self, text, channel):
-        text, attachments = g.main_window.read().get_status()
+        text, attachments = g.main_window.read().get_status("full" in text.lower())
         self.send_message(text, channel, attachments)
         
     def upload_file(self, file_path, title=None, first_comment=None, channel=None):

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ pyqtgraph
 pyserial
 slackclient
 slacker
+tidy_headers>=1.0.0

--- a/somatic/acquisition.py
+++ b/somatic/acquisition.py
@@ -169,37 +169,25 @@ class Worker(QtCore.QObject):
         # make data object
         data = wt.data.from_PyCMDS(data_path, verbose=False)
         data.save(data_path.replace('.data', '.p'), verbose=False)
-        # chop data if over 2D
-        if len(data.shape) > 2:
-            chopped_datas = data.chop(0, 1, verbose=False)
         # make figures for each channel
         data_path = pathlib.Path(data_path)
-        data_folder = str(data_path.parent)
+        data_folder = data_path.parent
         file_name = data_path.stem
         file_extension = data_path.suffix
         # chop data if over 2D
         for channel_index, channel_name in enumerate(data.channel_names):
+            output_folder = data_folder if data.ndim <= 2 else data_folder / channel_name
+            output_folder.mkdir(exist_ok=True)
             image_fname = channel_name + ' ' + file_name
             if len(data.shape) == 1:
-                artist = wt.artists.mpl_1D(data, verbose=False)
-                artist.plot(channel_index, autosave=True, output_folder=data_folder,
-                            fname=image_fname, verbose=False)
-            elif len(data.shape) == 2:
-                artist = wt.artists.mpl_2D(data, verbose=False)
-                artist.plot(channel_index, autosave=True, output_folder=data_folder,
+                outs = wt.artists.quick1D(data, channel=channel_index, autosave=True, output_folder=output_folder,
                             fname=image_fname, verbose=False)
             else:
-                channel_folder = os.path.join(data_folder, channel_name)
-                os.mkdir(channel_folder)
-                for index, chopped_data in enumerate(chopped_datas):
-                    this_image_fname = image_fname + str(index).zfill(3)
-                    artist = wt.artists.mpl_2D(chopped_data, verbose=False)
-                    artist.plot(channel_index, autosave=True, output_folder=channel_folder,
-                                fname=this_image_fname, verbose=False)
-                    g.app.read().processEvents()  # gui should not hang...
+                outs = wt.artists.quick2D(data, -1, -2, channel=channel_index, autosave=True, output_folder=output_folder,
+                            fname=image_fname, verbose=False)
             # hack in a way to get the first image written
             if channel_index == 0:
-                output_image_path = os.path.join(data_folder, image_fname + ' 000.png')
+                output_image_path = outs[0]
         # upload
         self.upload(self.scan_folders[self.scan_index], reference_image=output_image_path)
 

--- a/somatic/acquisition.py
+++ b/somatic/acquisition.py
@@ -8,6 +8,7 @@ Acquisition infrastructure shared by all modules.
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+import re
 import os
 import sys
 import imp
@@ -66,8 +67,9 @@ class Axis:
         self.hardware_dict = hardware_dict.copy()
         self.__dict__.update(kwargs)
         # fill hardware dictionary with defaults
-        names, operators = wt.kit.parse_identity(self.identity)
-        if 'F' in operators:  # last name should be a 'following' in this case
+        names = re.split("[=F]+", self.identity)
+        # KFS 2018-12-07: Is this still used at all? replacing wt2 kit.parse_identity
+        if 'F' in self.identity:  # last name should be a 'following' in this case
             names.pop(-1)
         for name in names:
             if name[0] == 'D':
@@ -171,7 +173,10 @@ class Worker(QtCore.QObject):
         if len(data.shape) > 2:
             chopped_datas = data.chop(0, 1, verbose=False)
         # make figures for each channel
-        data_folder, file_name, file_extension = wt.kit.filename_parse(data_path)
+        data_path = pathlib.Path(data_path)
+        data_folder = str(data_path.parent)
+        file_name = data_path.stem
+        file_extension = data_path.suffix
         # chop data if over 2D
         for channel_index, channel_name in enumerate(data.channel_names):
             image_fname = channel_name + ' ' + file_name

--- a/somatic/modules/motortune.py
+++ b/somatic/modules/motortune.py
@@ -208,6 +208,7 @@ class Worker(acquisition.Worker):
                 kwargs = {'centers': curve.colors}
             else:
                 center = self.aqn.read('spectrometer', 'center')
+                center = wt.units.convert(center, self.aqn.read('spectrometer', 'center units'), 'wn')
                 identity = name
                 kwargs = {}
             points = np.linspace(center-width, center+width, npts)
@@ -218,9 +219,13 @@ class Worker(acquisition.Worker):
                 # already handled above
                 pass
             else:
-                spectrometers.hardwares[0].set_position(self.aqn.read('spectrometer', 'center'), 'wn')
+                center = self.aqn.read('spectrometer', 'center')
+                center = wt.units.convert(center, self.aqn.read('spectrometer', 'center units'), 'wn')              
+                spectrometers.hardwares[0].set_position(center, 'wn')
         elif self.aqn.read('spectrometer', 'method') == 'Static':
-            spectrometers.hardwares[0].set_position(self.aqn.read('spectrometer', 'center'), 'wn')
+            center = self.aqn.read('spectrometer', 'center')
+            center = wt.units.convert(center, self.aqn.read('spectrometer', 'center units'), 'wn')
+            spectrometers.hardwares[0].set_position(center, 'wn')
         # handle centers
         for axis_index, axis in enumerate(axes):
             centers_shape = [a.points.size for i, a in enumerate(axes) if not i == axis_index]
@@ -262,7 +267,6 @@ class GUI(acquisition.GUI):
         self.mono_method_combo = pc.Combo(allowed, disable_under_module_control=True)
         self.mono_method_combo.updated.connect(self.update_mono_settings)
         self.mono_center = pc.Number(initial_value=7000, units='wn', disable_under_module_control=True)
-        self.mono_center.set_disabled_units(True)
         self.mono_width = pc.Number(initial_value=500, units='wn', disable_under_module_control=True)
         self.mono_width.set_disabled_units(True)
         self.mono_npts = pc.Number(initial_value=51, decimals=0, disable_under_module_control=True)
@@ -338,6 +342,7 @@ class GUI(acquisition.GUI):
         aqn.add_section('spectrometer')
         aqn.write('spectrometer', 'method', self.mono_method_combo.read())
         aqn.write('spectrometer', 'center', self.mono_center.read())
+        aqn.write('spectrometer', 'center units', self.mono_center.units)
         aqn.write('spectrometer', 'width', self.mono_width.read())
         aqn.write('spectrometer', 'number', self.mono_npts.read())
         # processing

--- a/somatic/modules/motortune.py
+++ b/somatic/modules/motortune.py
@@ -161,11 +161,11 @@ class Worker(acquisition.Worker):
                 identity = opa_friendly_name + '=wm'
                 hardware_dict = {opa_friendly_name: [opa_hardware, 'set_position_except', ['destination', motors_excepted]],
                                  'wm': [spectrometers.hardwares[0], 'set_position', None]}
-                axis = acquisition.Axis(curve.setpoints, curve.units, opa_friendly_name, identity, hardware_dict)
+                axis = acquisition.Axis(curve.setpoints[:], curve.setpoints.units, opa_friendly_name, identity, hardware_dict)
                 axes.append(axis)
             else:
                 hardware_dict = {opa_friendly_name: [opa_hardware, 'set_position_except', ['destination', motors_excepted]]}
-                axis = acquisition.Axis(curve.setpoints, curve.units, opa_friendly_name, opa_friendly_name, hardware_dict)
+                axis = acquisition.Axis(curve.setpoints[:], curve.setpoints.units, opa_friendly_name, opa_friendly_name, hardware_dict)
                 axes.append(axis)
         # motor
         for motor_index, motor_name in enumerate(motor_names):
@@ -203,8 +203,8 @@ class Worker(acquisition.Worker):
                 curve = curve.copy()
                 curve.convert('wn')
                 #centers_shape = [a.points.size for a in axes]
-                #centers = np.transpose(curve.setpoints * np.ones(centers_shape).T)
-                kwargs = {'centers': curve.setpoints}
+                #centers = np.transpose(curve.setpoints[:] * np.ones(centers_shape).T)
+                kwargs = {'centers': curve.setpoints[:]}
             else:
                 center = self.aqn.read('spectrometer', 'center')
                 center = wt.units.convert(center, self.aqn.read('spectrometer', 'center units'), 'wn')

--- a/somatic/modules/motortune.py
+++ b/somatic/modules/motortune.py
@@ -4,6 +4,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import os
+import pathlib
 import sys
 import time
 import numexpr as ne
@@ -115,7 +116,10 @@ class Worker(acquisition.Worker):
         # chop data if over 2D
         if len(data.shape) > 2:
             chopped_datas = data.chop(0, 1, verbose=False)
-        data_folder, file_name, file_extension = wt.kit.filename_parse(data_path)
+        data_path = pathlib.Path(data_path)
+        data_folder = str(data_path.parent)
+        file_name = data_path.stem
+        file_extension = data_path.suffix
         # make all images
         channel = self.aqn.read('processing', 'channel')
         image_fname = channel

--- a/somatic/modules/motortune.py
+++ b/somatic/modules/motortune.py
@@ -154,9 +154,9 @@ class Worker(acquisition.Worker):
         # tune points        
         if self.aqn.read('motortune', 'use tune points'):
             motors_excepted = []  # list of indicies  
-            for motor_index, motor_name in enumerate(motor_names):
+            for motor_name in motor_names:
                 if not self.aqn.read(motor_name, 'method') == 'Set':
-                    motors_excepted.append(motor_index)
+                    motors_excepted.append(motor_name)
             if self.aqn.read('spectrometer', 'method') == 'Set':
                 identity = opa_friendly_name + '=wm'
                 hardware_dict = {opa_friendly_name: [opa_hardware, 'set_position_except', ['destination', motors_excepted]],
@@ -168,7 +168,7 @@ class Worker(acquisition.Worker):
                 axis = acquisition.Axis(curve.setpoints[:], curve.setpoints.units, opa_friendly_name, opa_friendly_name, hardware_dict)
                 axes.append(axis)
         # motor
-        for motor_index, motor_name in enumerate(motor_names):
+        for motor_name in motor_names:
             if self.aqn.read(motor_name, 'method') == 'Scan':
                 motor_units = None
                 name = '_'.join([opa_friendly_name, motor_name])

--- a/somatic/modules/motortune.py
+++ b/somatic/modules/motortune.py
@@ -161,11 +161,11 @@ class Worker(acquisition.Worker):
                 identity = opa_friendly_name + '=wm'
                 hardware_dict = {opa_friendly_name: [opa_hardware, 'set_position_except', ['destination', motors_excepted]],
                                  'wm': [spectrometers.hardwares[0], 'set_position', None]}
-                axis = acquisition.Axis(curve.colors, curve.units, opa_friendly_name, identity, hardware_dict)
+                axis = acquisition.Axis(curve.setpoints, curve.units, opa_friendly_name, identity, hardware_dict)
                 axes.append(axis)
             else:
                 hardware_dict = {opa_friendly_name: [opa_hardware, 'set_position_except', ['destination', motors_excepted]]}
-                axis = acquisition.Axis(curve.colors, curve.units, opa_friendly_name, opa_friendly_name, hardware_dict)
+                axis = acquisition.Axis(curve.setpoints, curve.units, opa_friendly_name, opa_friendly_name, hardware_dict)
                 axes.append(axis)
         # motor
         for motor_index, motor_name in enumerate(motor_names):
@@ -177,8 +177,7 @@ class Worker(acquisition.Worker):
                 if self.aqn.read('motortune', 'use tune points'):
                     center = 0.
                     identity = 'D'+name
-                    curve_motor_index = curve.get_motor_names(full=False).index(motor_name)
-                    motor_positions = curve.motors[curve_motor_index].positions
+                    motor_positions = curve[motor_name][:]
                     kwargs = {'centers': motor_positions}
                 else:
                     center = self.aqn.read(motor_name, 'center')
@@ -204,8 +203,8 @@ class Worker(acquisition.Worker):
                 curve = curve.copy()
                 curve.convert('wn')
                 #centers_shape = [a.points.size for a in axes]
-                #centers = np.transpose(curve.colors * np.ones(centers_shape).T)
-                kwargs = {'centers': curve.colors}
+                #centers = np.transpose(curve.setpoints * np.ones(centers_shape).T)
+                kwargs = {'centers': curve.setpoints}
             else:
                 center = self.aqn.read('spectrometer', 'center')
                 center = wt.units.convert(center, self.aqn.read('spectrometer', 'center units'), 'wn')

--- a/somatic/modules/poynting_tune.py
+++ b/somatic/modules/poynting_tune.py
@@ -66,7 +66,7 @@ class Worker(acquisition.Worker):
         curve = opa_hardware.curve.copy()
         curve.convert('wn')
 
-        axis = acquisition.Axis(curve.colors, 'wn', opa_name, opa_name)
+        axis = acquisition.Axis(curve.setpoints, 'wn', opa_name, opa_name)
         possible_axes[opa_name] = axis
 
         self.do_2D = self.aqn.read('processing', 'do_2D_scans')

--- a/somatic/modules/poynting_tune.py
+++ b/somatic/modules/poynting_tune.py
@@ -46,7 +46,7 @@ class Worker(acquisition.Worker):
             data_path = wt.kit.glob_handler('.data', folder=scan_folder)[0]
             data = wt.data.from_PyCMDS(data_path)
             channel_name = self.aqn.read('processing', 'channel')
-            wt.tuning.workup.tune_test(data, curve, channel_name, save_directory=scan_folder)
+            attune.workup.tune_test(data, curve, channel_name, save_directory=scan_folder)
             # upload
             self.upload(scan_folder, reference_image=os.path.join(scan_folder, 'tune test.png'))
     
@@ -113,7 +113,7 @@ class Worker(acquisition.Worker):
                     p = os.path.join(scan_folder, '000.data')
                     data = wt.data.from_PyCMDS(p)
                     channel = self.aqn.read('processing', 'channel')
-                    wt.tuning.workup.intensity(data, curve, channel, save_directory = scan_folder, cutoff_factor=1e-3)
+                    attune.workup.intensity(data, curve, channel, save_directory = scan_folder, cutoff_factor=1e-3)
 
                     p = wt.kit.glob_handler('.curve', folder = scan_folder)[0]
                     opa_hardware.driver.curve_paths['Poynting'].write(p)

--- a/somatic/modules/poynting_tune.py
+++ b/somatic/modules/poynting_tune.py
@@ -66,7 +66,7 @@ class Worker(acquisition.Worker):
         curve = opa_hardware.curve.copy()
         curve.convert('wn')
 
-        axis = acquisition.Axis(curve.setpoints, 'wn', opa_name, opa_name)
+        axis = acquisition.Axis(curve.setpoints[:], 'wn', opa_name, opa_name)
         possible_axes[opa_name] = axis
 
         self.do_2D = self.aqn.read('processing', 'do_2D_scans')

--- a/somatic/modules/poynting_tune.py
+++ b/somatic/modules/poynting_tune.py
@@ -81,9 +81,8 @@ class Worker(acquisition.Worker):
                         width = self.aqn.read(section,'width')
                         npts = int(self.aqn.read(section,'number'))
                         points = np.linspace(-width/2.,width/2., npts)
-                        motor_positions = curve.motors[curve.motor_names.index(section)].positions
+                        motor_positions = curve[section][:]
                         kwargs = {'centers': motor_positions}
-                        print(opa_hardware.driver.motor_names)
                         hardware_dict = {opa_name: [opa_hardware, 'set_motor', [section, 'destination']]}
                         axis = acquisition.Axis(points, None, opa_name+'_'+section, 'D'+opa_name, hardware_dict, **kwargs)
                         possible_axes[section] = axis
@@ -231,7 +230,7 @@ class OPA_GUI():
         self.hardware = hardware
         print(hardware.__class__)
         curve = self.hardware.curve
-        motor_names = curve.motor_names
+        motor_names = curve.dependent_names
         self.motors = []
         for name in motor_names:
             motor = MotorGUI(name,1000,31)

--- a/somatic/modules/poynting_tune.py
+++ b/somatic/modules/poynting_tune.py
@@ -47,6 +47,9 @@ class Worker(acquisition.Worker):
             data_path = wt.kit.glob_handler('.data', folder=scan_folder)[0]
             data = wt.data.from_PyCMDS(data_path)
             channel_name = self.aqn.read('processing', 'channel')
+            transform = list(data.axis_names)
+            transform[-1] = transform[-1] + "_points"
+            data.transform(*transform)
             attune.workup.tune_test(data, curve, channel_name, save_directory=scan_folder)
             # upload
             self.upload(scan_folder, reference_image=os.path.join(scan_folder, 'tune test.png'))
@@ -114,6 +117,9 @@ class Worker(acquisition.Worker):
                     p = os.path.join(scan_folder, '000.data')
                     data = wt.data.from_PyCMDS(p)
                     channel = self.aqn.read('processing', 'channel')
+                    transform = list(data.axis_names)
+                    transform[-1] = transform[-1] + "_points"
+                    data.transform(*transform)
                     attune.workup.intensity(data, curve, channel, save_directory = scan_folder, cutoff_factor=1e-3)
 
                     p = wt.kit.glob_handler('.curve', folder = scan_folder)[0]

--- a/somatic/modules/poynting_tune.py
+++ b/somatic/modules/poynting_tune.py
@@ -118,7 +118,7 @@ class Worker(acquisition.Worker):
                     channel = self.aqn.read('processing', 'channel')
                     transform = list(data.axis_names)
                     dep = transform[-1]
-                    transform[-1] = transform[-1] + "_points"
+                    transform[-1] = f"{transform[0]}_{dep}_points"
                     data.transform(*transform)
                     attune.workup.intensity(data, channel, dep, curve, save_directory = scan_folder, cutoff_factor=1e-3)
 

--- a/somatic/modules/poynting_tune.py
+++ b/somatic/modules/poynting_tune.py
@@ -108,8 +108,6 @@ class Worker(acquisition.Worker):
                     axes.append(possible_axes[opa_name])
                     axes.append(axis)
                     
-                    print("POYNTING TUNE SCAN", axis.centers)
-
                     scan_folder = self.scan(axes)
 
                     #process
@@ -117,7 +115,7 @@ class Worker(acquisition.Worker):
                     data = wt.data.from_PyCMDS(p)
                     channel = self.aqn.read('processing', 'channel')
                     transform = list(data.axis_names)
-                    dep = transform[-1]
+                    dep = name
                     transform[-1] = f"{transform[0]}_{dep}_points"
                     data.transform(*transform)
                     attune.workup.intensity(data, channel, dep, curve, save_directory = scan_folder, cutoff_factor=1e-3)

--- a/somatic/modules/poynting_tune.py
+++ b/somatic/modules/poynting_tune.py
@@ -50,7 +50,7 @@ class Worker(acquisition.Worker):
             transform = list(data.axis_names)
             transform[-1] = transform[-1] + "_points"
             data.transform(*transform)
-            attune.workup.tune_test(data, curve, channel_name, save_directory=scan_folder)
+            attune.workup.tune_test(data, channel_name, save_directory=scan_folder)
             # upload
             self.upload(scan_folder, reference_image=os.path.join(scan_folder, 'tune test.png'))
     
@@ -118,9 +118,10 @@ class Worker(acquisition.Worker):
                     data = wt.data.from_PyCMDS(p)
                     channel = self.aqn.read('processing', 'channel')
                     transform = list(data.axis_names)
+                    dep = transform[-1]
                     transform[-1] = transform[-1] + "_points"
                     data.transform(*transform)
-                    attune.workup.intensity(data, curve, channel, save_directory = scan_folder, cutoff_factor=1e-3)
+                    attune.workup.intensity(data, channel, dep, curve, save_directory = scan_folder, cutoff_factor=1e-3)
 
                     p = wt.kit.glob_handler('.curve', folder = scan_folder)[0]
                     opa_hardware.driver.curve_paths['Poynting'].write(p)

--- a/somatic/modules/poynting_tune.py
+++ b/somatic/modules/poynting_tune.py
@@ -15,6 +15,7 @@ matplotlib.pyplot.ioff()
 
 from PyQt4 import QtCore, QtGui
 import WrightTools as wt
+import attune
 
 import project.project_globals as g
 import project.classes as pc

--- a/somatic/modules/scan.py
+++ b/somatic/modules/scan.py
@@ -127,49 +127,41 @@ class Worker(acquisition.Worker):
         # make data object
         data = wt.data.from_PyCMDS(data_path, verbose=False)
         # decide which channels to make plots for
+        main_channel = self.aqn.read('processing', 'main channel')
         if self.aqn.read('processing', 'process all channels'):
             channels = data.channel_names
         else:
-            channels = [self.aqn.read('processing', 'main channel')]
-        # chop data if over 2D
-        if len(data.shape) > 2:
-            chopped_datas = data.chop(0, 1, verbose=False)
+            channels = [main_channel]
         # make figures for each channel
         data_path = pathlib.Path(data_path)
-        data_folder = str(data_path.parent)
+        data_folder = data_path.parent
+        channel_path = data_folder / channel_name
+        output_path = data_folder
+        if data.ndim > 2:
+            output_path = channel_path
+            channel_path.mkdir()
         file_name = data_path.stem
         file_extension = data_path.suffix
         # make all images
         for channel_name in channels:
             channel_index = data.channel_names.index(channel_name)
             image_fname = channel_name
-            if len(data.shape) == 1:
-                artist = wt.artists.mpl_1D(data, verbose=False)
-                artist.plot(channel_index, autosave=True, output_folder=data_folder,
-                            fname=image_fname, verbose=False)
-            elif len(data.shape) == 2:
-                artist = wt.artists.mpl_2D(data, verbose=False)
-                artist.plot(channel_index, autosave=True, output_folder=data_folder,
+            if data.ndim == 1:
+                outs = wt.artists.quick1D(data, channel=channel_index, autosave=True, output_folder=output_folder,
                             fname=image_fname, verbose=False)
             else:
-                channel_folder = os.path.join(data_folder, channel_name)
-                os.mkdir(channel_folder)
-                for index, chopped_data in enumerate(chopped_datas):
-                    this_image_fname = image_fname + ' ' + str(index).zfill(3)
-                    artist = wt.artists.mpl_2D(chopped_data, verbose=False)
-                    artist.plot(channel_index, autosave=True, output_folder=channel_folder,
-                                fname=this_image_fname, verbose=False)
+                outs = wt.artists.quick2D(data, -1, -2, channel=channel_index, autosave=True, output_folder=output_folder,
+                            fname=image_fname, verbose=False)
+            if channel_name == main_channel:
+                outputs = outs
         # get output image
-        main_channel = self.aqn.read('processing', 'main channel')
-        if len(data.shape) <= 2:
-            output_image_path = os.path.join(scan_folder, main_channel + ' 000.png')
+        if len(outputs) == 1:
+            output_image_path = outputs[0]
         else:
-            output_folder = os.path.join(data_folder, main_channel)
-            output_image_path = os.path.join(output_folder, 'animation.gif')
-            images = wt.kit.glob_handler('.png', folder=output_folder)
-            wt.artists.stitch_to_animation(images=images, outpath=output_image_path)
+            output_image_path = output_path / 'animation.gif'
+            wt.artists.stitch_to_animation(images=outputs, outpath=output_image_path)
         # upload
-        self.upload(scan_folder, reference_image=output_image_path)
+        self.upload(scan_folder, reference_image=str(output_image_path))
     
     def run(self):
         # axes

--- a/somatic/modules/scan.py
+++ b/somatic/modules/scan.py
@@ -135,22 +135,22 @@ class Worker(acquisition.Worker):
         # make figures for each channel
         data_path = pathlib.Path(data_path)
         data_folder = data_path.parent
-        channel_path = data_folder / channel_name
-        output_path = data_folder
-        if data.ndim > 2:
-            output_path = channel_path
-            channel_path.mkdir()
         file_name = data_path.stem
         file_extension = data_path.suffix
         # make all images
         for channel_name in channels:
+            channel_path = data_folder / channel_name
+            output_path = data_folder
+            if data.ndim > 2:
+                output_path = channel_path
+                channel_path.mkdir()
             channel_index = data.channel_names.index(channel_name)
             image_fname = channel_name
             if data.ndim == 1:
-                outs = wt.artists.quick1D(data, channel=channel_index, autosave=True, output_folder=output_folder,
+                outs = wt.artists.quick1D(data, channel=channel_index, autosave=True, save_directory=output_path,
                             fname=image_fname, verbose=False)
             else:
-                outs = wt.artists.quick2D(data, -1, -2, channel=channel_index, autosave=True, output_folder=output_folder,
+                outs = wt.artists.quick2D(data, -1, -2, channel=channel_index, autosave=True, save_directory=output_path,
                             fname=image_fname, verbose=False)
             if channel_name == main_channel:
                 outputs = outs
@@ -293,9 +293,9 @@ class GUI(acquisition.GUI):
         for axis_index, axis_name in enumerate(axis_names):
             units = aqn.read(axis_name, 'units')
             units_kind = None
-            for d in wt.units.dicts:
+            for kind, d in wt.units.dicts.items():
                 if units in d.keys():
-                    units_kind = d['kind']
+                    units_kind = kind
             axis = Axis(units_kind, axis_index)
             axis.start.write(aqn.read(axis_name, 'start'))
             axis.stop.write(aqn.read(axis_name, 'stop'))

--- a/somatic/modules/scan.py
+++ b/somatic/modules/scan.py
@@ -4,6 +4,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import os
+import pathlib
 import sys
 import time
 import numexpr as ne
@@ -134,7 +135,10 @@ class Worker(acquisition.Worker):
         if len(data.shape) > 2:
             chopped_datas = data.chop(0, 1, verbose=False)
         # make figures for each channel
-        data_folder, file_name, file_extension = wt.kit.filename_parse(data_path)
+        data_path = pathlib.Path(data_path)
+        data_folder = str(data_path.parent)
+        file_name = data_path.stem
+        file_extension = data_path.suffix
         # make all images
         for channel_name in channels:
             channel_index = data.channel_names.index(channel_name)

--- a/somatic/modules/scan.py
+++ b/somatic/modules/scan.py
@@ -293,7 +293,7 @@ class GUI(acquisition.GUI):
         for axis_index, axis_name in enumerate(axis_names):
             units = aqn.read(axis_name, 'units')
             units_kind = None
-            for d in wt.units.unit_dicts:
+            for d in wt.units.dicts:
                 if units in d.keys():
                     units_kind = d['kind']
             axis = Axis(units_kind, axis_index)

--- a/somatic/modules/tune_test.py
+++ b/somatic/modules/tune_test.py
@@ -59,7 +59,7 @@ class Worker(acquisition.Worker):
         data.transform(*transform)
         attune.workup.tune_test(data, channel_name, curve, save_directory=scan_folder)
         # upload
-        self.upload(scan_folder, reference_image=os.path.join(scan_folder, 'tune test.png'))
+        self.upload(scan_folder, reference_image=os.path.join(scan_folder, 'tune_test.png'))
     
     def run(self):
         axes = []
@@ -71,12 +71,12 @@ class Worker(acquisition.Worker):
         opa_friendly_name = opa_hardware.name
         curve = opa_hardware.curve.copy()
         curve.convert('wn')
-        axis = acquisition.Axis(curve.setpoints, 'wn', opa_friendly_name, opa_friendly_name)
+        axis = acquisition.Axis(curve.setpoints[:], 'wn', opa_friendly_name, opa_friendly_name)
         axes.append(axis)
         # mono
         name = 'wm'
         identity = 'Dwm'
-        kwargs = {'centers': curve.setpoints}
+        kwargs = {'centers': curve.setpoints[:]}
         width = self.aqn.read('spectrometer', 'width')/2.
         npts = self.aqn.read('spectrometer', 'number')
         points = np.linspace(-width, width, npts)

--- a/somatic/modules/tune_test.py
+++ b/somatic/modules/tune_test.py
@@ -57,7 +57,7 @@ class Worker(acquisition.Worker):
         transform = list(data.axis_names)
         transform[-1] = transform[-1] + "_points"
         data.transform(*transform)
-        attune.workup.tune_test(data, curve, channel_name, save_directory=scan_folder)
+        attune.workup.tune_test(data, channel_name, curve, save_directory=scan_folder)
         # upload
         self.upload(scan_folder, reference_image=os.path.join(scan_folder, 'tune test.png'))
     

--- a/somatic/modules/tune_test.py
+++ b/somatic/modules/tune_test.py
@@ -71,12 +71,12 @@ class Worker(acquisition.Worker):
         opa_friendly_name = opa_hardware.name
         curve = opa_hardware.curve.copy()
         curve.convert('wn')
-        axis = acquisition.Axis(curve.colors, 'wn', opa_friendly_name, opa_friendly_name)
+        axis = acquisition.Axis(curve.setpoints, 'wn', opa_friendly_name, opa_friendly_name)
         axes.append(axis)
         # mono
         name = 'wm'
         identity = 'Dwm'
-        kwargs = {'centers': curve.colors}
+        kwargs = {'centers': curve.setpoints}
         width = self.aqn.read('spectrometer', 'width')/2.
         npts = self.aqn.read('spectrometer', 'number')
         points = np.linspace(-width, width, npts)

--- a/somatic/modules/tune_test.py
+++ b/somatic/modules/tune_test.py
@@ -53,7 +53,7 @@ class Worker(acquisition.Worker):
         if curve.kind == 'poynting':
             curve = curve.subcurve
         channel_name = self.aqn.read('processing', 'channel')
-        wt.tuning.workup.tune_test(data, curve, channel_name, save_directory=scan_folder)
+        attune.workup.tune_test(data, curve, channel_name, save_directory=scan_folder)
         # upload
         self.upload(scan_folder, reference_image=os.path.join(scan_folder, 'tune test.png'))
     

--- a/somatic/modules/tune_test.py
+++ b/somatic/modules/tune_test.py
@@ -54,8 +54,15 @@ class Worker(acquisition.Worker):
         if curve.kind == 'poynting':
             curve = curve.subcurve
         channel_name = self.aqn.read('processing', 'channel')
+        try:
+            order = int(self.aqn.read('spectrometer', 'order'))
+        except KeyError:
+            order = 1
         transform = list(data.axis_names)
-        transform[-1] = transform[-1] + f"_points/{int(self.aqn.read('spectrometer', 'order'))}"
+        if order > 0
+            transform[-1] = f"{transform[-1]}_points/{order}"
+        else:
+            transform[-1] = f"{transform[-1]}_points*{abs(order)}"
         data.transform(*transform)
         attune.workup.tune_test(data, channel_name, curve, save_directory=scan_folder)
         # upload
@@ -76,7 +83,16 @@ class Worker(acquisition.Worker):
         # mono
         name = 'wm'
         identity = 'Dwm'
-        kwargs = {'centers': curve.setpoints[:] * self.aqn.read('spectrometer', 'order')}
+        try:
+            order = self.aqn.read('spectrometer', 'order')
+        except KeyError:
+            order = 1
+        if order == 0:
+            raise ValueError("Spectrometer order cannot be 0")
+        elif order > 0
+            kwargs = {'centers': curve.setpoints[:] * self.aqn.read('spectrometer', 'order')}
+        else:
+            kwargs = {'centers': curve.setpoints[:] / abs(self.aqn.read('spectrometer', 'order'))}
         width = self.aqn.read('spectrometer', 'width')/2.
         npts = self.aqn.read('spectrometer', 'number')
         points = np.linspace(-width, width, npts)

--- a/somatic/modules/tune_test.py
+++ b/somatic/modules/tune_test.py
@@ -54,6 +54,9 @@ class Worker(acquisition.Worker):
         if curve.kind == 'poynting':
             curve = curve.subcurve
         channel_name = self.aqn.read('processing', 'channel')
+        transform = list(data.axis_names)
+        transform[-1] = transform[-1] + "_points"
+        data.transform(*transform)
         attune.workup.tune_test(data, curve, channel_name, save_directory=scan_folder)
         # upload
         self.upload(scan_folder, reference_image=os.path.join(scan_folder, 'tune test.png'))

--- a/somatic/modules/tune_test.py
+++ b/somatic/modules/tune_test.py
@@ -55,7 +55,7 @@ class Worker(acquisition.Worker):
             curve = curve.subcurve
         channel_name = self.aqn.read('processing', 'channel')
         transform = list(data.axis_names)
-        transform[-1] = transform[-1] + f"_points__d__{self.aqn.read('spectrometer', 'order')}"
+        transform[-1] = transform[-1] + f"_points/{int(self.aqn.read('spectrometer', 'order'))}"
         data.transform(*transform)
         attune.workup.tune_test(data, channel_name, curve, save_directory=scan_folder)
         # upload

--- a/somatic/modules/tune_test.py
+++ b/somatic/modules/tune_test.py
@@ -15,6 +15,7 @@ matplotlib.pyplot.ioff()
 
 from PyQt4 import QtCore, QtGui
 import WrightTools as wt
+import attune
 
 import project.project_globals as g
 import project.classes as pc

--- a/somatic/modules/zero_tune.py
+++ b/somatic/modules/zero_tune.py
@@ -60,7 +60,7 @@ class Worker(acquisition.Worker):
         color_units = [i.units for i in data.axes if wt.units.kind(i.units) == 'energy'][0]
         delay_units = [i.units for i in data.axes if wt.units.kind(i.units) == 'delay'][0]
         for delay in delays: 
-            attune.spectral_delay_correction.process_wigner(data, channel_name, opa_name, delay, "{}_{}".format(opa_name, delay), global_cutoff_factor = 0, color_units=color_units, delay_units=delay_units, save_directory=scan_folder)
+            attune.workup.intensity(data, channel_name, delay, cutoff_factor=0, save_directory=scan_folder)
         # upload
         self.upload(scan_folder)
     

--- a/somatic/modules/zero_tune.py
+++ b/somatic/modules/zero_tune.py
@@ -74,7 +74,7 @@ class Worker(acquisition.Worker):
         opa_friendly_name = opa_hardware.name
         curve = opa_hardware.curve.copy()
         curve.convert('wn')
-        axis = acquisition.Axis(curve.colors, 'wn', opa_friendly_name, opa_friendly_name)
+        axis = acquisition.Axis(curve.setpoints, 'wn', opa_friendly_name, opa_friendly_name)
         axes.append(axis)
         # delay
         axis_name = 'delay'

--- a/somatic/modules/zero_tune.py
+++ b/somatic/modules/zero_tune.py
@@ -74,7 +74,7 @@ class Worker(acquisition.Worker):
         opa_friendly_name = opa_hardware.name
         curve = opa_hardware.curve.copy()
         curve.convert('wn')
-        axis = acquisition.Axis(curve.setpoints, 'wn', opa_friendly_name, opa_friendly_name)
+        axis = acquisition.Axis(curve.setpoints[:], 'wn', opa_friendly_name, opa_friendly_name)
         axes.append(axis)
         # delay
         axis_name = 'delay'

--- a/somatic/modules/zero_tune.py
+++ b/somatic/modules/zero_tune.py
@@ -15,6 +15,7 @@ matplotlib.pyplot.ioff()
 
 from PyQt4 import QtCore, QtGui
 import WrightTools as wt
+import attune
 
 import project.project_globals as g
 import project.classes as pc

--- a/somatic/modules/zero_tune.py
+++ b/somatic/modules/zero_tune.py
@@ -59,7 +59,7 @@ class Worker(acquisition.Worker):
         color_units = [i.units for i in data.axes if wt.units.kind(i.units) == 'energy'][0]
         delay_units = [i.units for i in data.axes if wt.units.kind(i.units) == 'delay'][0]
         for delay in delays: 
-            wt.tuning.spectral_delay_correction.process_wigner(data, channel_name, opa_name, delay, "{}_{}".format(opa_name, delay), global_cutoff_factor = 0, color_units=color_units, delay_units=delay_units, save_directory=scan_folder)
+            attune.spectral_delay_correction.process_wigner(data, channel_name, opa_name, delay, "{}_{}".format(opa_name, delay), global_cutoff_factor = 0, color_units=color_units, delay_units=delay_units, save_directory=scan_folder)
         # upload
         self.upload(scan_folder)
     

--- a/somatic/queue.py
+++ b/somatic/queue.py
@@ -452,7 +452,7 @@ class Queue():
         string = ':'.join([str(int(h)).zfill(3), str(int(m)).zfill(2), str(int(s)).zfill(2)])
         return string
 
-    def interrupt(self, message='Please choose how to proceed.'):
+    def interrupt(self, option=None, message='Please choose how to proceed.'):
         self.gui.queue_control.set_style('WAITING', 'stop')
         # pause
         self.status.pause.write(True)
@@ -461,7 +461,10 @@ class Queue():
         # ask user how to proceed
         options = ['RESUME', 'SKIP', 'STOP']
         self.gui.interrupt_choice_window.set_text(message)
-        index_chosen = self.gui.interrupt_choice_window.show()
+        if option is None:
+            index_chosen = self.gui.interrupt_choice_window.show()
+        else:
+            index_chosen = wt.kit.get_index(options, option)
         chosen = options[index_chosen]
         # proceed
         if chosen == 'RESUME':
@@ -875,7 +878,7 @@ class GUI(QtCore.QObject):
         layout.addWidget(input_table)
         return frame
     
-    def get_status(self):
+    def get_status(self, full=False):
         # called by slack
         make_field = g.slack_control.read().make_field
         make_attachment = g.slack_control.read().make_attachment
@@ -901,6 +904,8 @@ class GUI(QtCore.QObject):
             attachments.append(make_attachment('', fields=fields, color='#00FFFF'))
             # queue items 
             for item_index, item in enumerate(self.queue.items):
+                if not full and item.status != "RUNNING":
+                    continue
                 name = ' - '.join([str(item_index).zfill(3), item.type, item.description])
                 fields = []
                 if item.started is not None:

--- a/somatic/queue.py
+++ b/somatic/queue.py
@@ -1164,12 +1164,11 @@ class GUI(QtCore.QObject):
 
     def save_aqn(self, folder):
         # all aqn files are first created using this method
-        now = time.time()
         # get filepath
         module_name = self.module_combobox.read()
         name = self.acquisition_name.read()
-        timestamp = wt.kit.get_timestamp(style='short', at=now)
-        aqn_name = ' '.join([timestamp, module_name, name]).rstrip() + '.aqn'
+        timestamp = wt.kit.TimeStamp()
+        aqn_name = ' '.join([timestamp.path, module_name, name]).rstrip() + '.aqn'
         p = os.path.join(folder, aqn_name)
         # create file
         with open(p, 'a'):
@@ -1178,7 +1177,7 @@ class GUI(QtCore.QObject):
         ini = wt.kit.INI(p)
         ini.add_section('info')
         ini.write('info', 'PyCMDS version', g.version.read())
-        ini.write('info', 'created', wt.kit.get_timestamp(at=now))
+        ini.write('info', 'created', timestamp.RFC3339)
         ini.write('info', 'module', module_name)
         ini.write('info', 'name', name)
         ini.write('info', 'info', self.acquisition_info.read())


### PR DESCRIPTION
This is a lot of things all rolled into one branch because I needed them on the ps system...

This supercedes #201 

Features include: 
- Removing/renaming calls to WT2 that have been moved/exported to attune, tidy_headers, etc.
- Addition of google drive code previously found in WT, but no longer in WT3
- Changes tracking current master of attune for how curves are structured/handled.
- New slack witch commands: `run`, `interrupt`, and `screenshot`
- Improved `@witch status`/`help`
- using names to refer to motors rather than indices (where possible)