### PR TITLE
Remove lines which errantly set topas position

### DIFF
--- a/hardware/opas/TOPAS/TOPAS.py
+++ b/hardware/opas/TOPAS/TOPAS.py
@@ -503,11 +503,6 @@ class Driver(BaseDriver):
             number = pc.Number(initial_value=0, limits=limits, display=True, decimals=6)
             self.motor_positions[motor_name] = number
             self.recorded['w%d_'%self.index + motor_name] = [number, None, 1., motor_name]
-        #self.get_motor_positions()
-        # set position
-        position = self.ini.read('OPA%i'%self.index, 'position (nm)')
-        self.hardware.destination.write(position, self.native_units)
-        #self.set_position(position) #TODO make sure set position is handled in the base class
         # finish
         BaseDriver.initialize(self)
 


### PR DESCRIPTION
Closes #172

These lines seemed to do nothing other than set the _incorrect_ value read from a file in which the key in question doesn't get updated.

Without these lines, the correct value was there on start up. (Admittedly small N, but I think it makes sense as the correct value is stored in the ini file which is used by the base class, just like OPA-800s)