### PR TITLE
Enquable Queue Interrupt

### DIFF
--- a/project/widgets.py
+++ b/project/widgets.py
@@ -607,16 +607,6 @@ class HardwareAdvancedPanel(QtCore.QObject):
 ### queue #####################################################################
         
 
-# TODO: remove
-class module_combobox(QtWidgets.QComboBox):
-    # TODO: remove this legacy widget
-    shutdown_go = QtCore.Signal()
-    def __init__(self):
-        QtWidgets.QComboBox.__init__(self)
-        StyleSheet = 'QComboBox{font: bold 14px}'#.replace('custom_color', colors['background'])
-        self.setStyleSheet(StyleSheet)
-
-      
 class QueueControl(QtWidgets.QPushButton):
     launch_scan = QtCore.Signal()
     stop_scan = QtCore.Signal()
@@ -636,9 +626,8 @@ class QueueControl(QtWidgets.QPushButton):
 
 class ChoiceWindow(QtWidgets.QMessageBox):
 
-    def __init__(self, title, button_labels, block=True):
+    def __init__(self, title, button_labels):
         QtWidgets.QMessageBox.__init__(self)
-        self.block = block
         self.setWindowTitle(title)
         self.setWindowFlags(QtCore.Qt.WindowStaysOnTopHint)
         for label in button_labels:
@@ -656,8 +645,7 @@ class ChoiceWindow(QtWidgets.QMessageBox):
         Returns the index of the chosen button
         '''
         self.isActiveWindow()
-        if self.block:
-            self.setFocusPolicy(QtCore.Qt.StrongFocus)
+        self.setFocusPolicy(QtCore.Qt.StrongFocus)
         return self.exec_()
 
 
@@ -753,68 +741,3 @@ class Plot1D(pg.GraphicsView):
             
     def clear(self):
         self.plot_object.clear()
-
-        
-### pop-ups ###################################################################
-
-
-class choice_window(QtWidgets.QMessageBox):
-
-    def __init__(self):
-        QtWidgets.QMessageBox.__init__(self)
-
-    def say(self, window_title, text, buttons, icon = 'NoIcon', informative_text=''):
-        '''
-        icon choices: NoIcon, Question, Information, Warning, Critical \n
-        returns index of button chosen as integer
-        '''
-        #self.size()
-        self.setWindowTitle(window_title)
-        self.setText(text)
-        self.setInformativeText(informative_text)
-        self.setIcon(getattr(self, icon))
-        for label in buttons:
-            my_button = QtWidgets.QPushButton(label)
-            self.addButton(my_button, QtWidgets.QMessageBox.YesRole)
-        self.isActiveWindow()
-        self.setFocusPolicy(QtCore.Qt.StrongFocus)
-        return self.exec_()
-
-
-class MessageWindow(QtWidgets.QWidget):
-
-    def __init__(self, text='Please wait.', title='Wait'):
-        QtWidgets.QWidget.__init__(self, parent=None)
-        self.setWindowTitle(title)
-        self.isActiveWindow()
-        self.setFocusPolicy(QtCore.Qt.StrongFocus)
-        #disable 'x'
-        self.setWindowFlags(self.windowFlags() | QtCore.Qt.CustomizeWindowHint)
-        self.setWindowFlags(self.windowFlags() & ~QtCore.Qt.WindowCloseButtonHint)
-        # set geometry
-        self.window_verti_size = 50
-        self.window_horiz_size = 200
-        self.setGeometry(0,0, self.window_horiz_size, self.window_verti_size)
-        self._center()
-        # add content
-        self.label = QtWidgets.QLabel(text)
-        self.label.setAlignment(QtCore.Qt.AlignCenter)
-        layout = QtWidgets.QHBoxLayout()
-        layout.addWidget(self.label)
-        self.setLayout(layout)
-        # finish
-        self.show()
-        self.hide()
-      
-    def _center(self):
-        # a function which ensures that the window appears in the center of the screen at startup
-        screen = QtWidgets.QDesktopWidget().screenGeometry() 
-        size = self.geometry() 
-        self.move((screen.width()-size.width())/2, (screen.height()-size.height())/2)
-
-
-### testing ###################################################################
-    
-        
-if __name__ == '__main__':
-    plt = Plot1D()

--- a/project/widgets.py
+++ b/project/widgets.py
@@ -636,9 +636,11 @@ class QueueControl(QtWidgets.QPushButton):
 
 class ChoiceWindow(QtWidgets.QMessageBox):
 
-    def __init__(self, title, button_labels):
+    def __init__(self, title, button_labels, block=True):
         QtWidgets.QMessageBox.__init__(self)
+        self.block = block
         self.setWindowTitle(title)
+        self.setWindowFlags(QtCore.Qt.WindowStaysOnTopHint)
         for label in button_labels:
             self.addButton(label, QtWidgets.QMessageBox.YesRole)
         self.setIcon(self.NoIcon)
@@ -654,7 +656,8 @@ class ChoiceWindow(QtWidgets.QMessageBox):
         Returns the index of the chosen button
         '''
         self.isActiveWindow()
-        self.setFocusPolicy(QtCore.Qt.StrongFocus)
+        if self.block:
+            self.setFocusPolicy(QtCore.Qt.StrongFocus)
         return self.exec_()
 
 

--- a/somatic/acquisition.py
+++ b/somatic/acquisition.py
@@ -26,7 +26,6 @@ from PySide2 import QtCore, QtWidgets
 import WrightTools as wt
 
 import project.project_globals as g
-import project.widgets as pw
 app = g.app.read()
 
 import hardware.spectrometers.spectrometers as spectrometers

--- a/somatic/acquisition.py
+++ b/somatic/acquisition.py
@@ -394,7 +394,6 @@ class GUI(QtCore.QObject):
     def __init__(self, module_name):
         QtCore.QObject.__init__(self)
         self.module_name = module_name
-        self.wait_window = pw.MessageWindow(title=self.module_name, text='Please wait.')
         # create frame
         self.layout = QtWidgets.QVBoxLayout()
         self.layout.setMargin(0)

--- a/somatic/queue.py
+++ b/somatic/queue.py
@@ -402,10 +402,9 @@ class Queue():
         if isinstance(item, Interrupt):
             self.status.go.write(False)
             if item.message.strip():
-                options = ['OKAY']
-                choice_window = pw.ChoiceWindow(f"Interrupted - {item.description}", button_labels=options)
-                choice_window.set_informative_text(item.message)
-                choice_window.show()
+                msg = QtWidgets.QMessageBox(QtWidgets.QMessageBox.NoIcon, "Interrupt", item.message, QtWidgets.QMessageBox.Ok, parent=self.gui.parent_widget)
+                msg.setModal(False)
+                msg.show()
         self.worker_q.push('excecute', item)
         self.gui.message_widget.setText(item.description.upper())
 
@@ -600,6 +599,7 @@ class GUI(QtCore.QObject):
         self.progress_bar = g.progress_bar
         # frame, widgets
         self.message_widget = message_widget
+        self.parent_widget = parent_widget
         parent_widget.setLayout(QtWidgets.QHBoxLayout())
         parent_widget.layout().setContentsMargins(0, 10, 0, 0)
         self.layout = parent_widget.layout()

--- a/somatic/queue.py
+++ b/somatic/queue.py
@@ -539,7 +539,7 @@ class Queue():
         return out
 
     def resume_queue(self, button):
-        if button.text() == "Resume Queue":
+        if not self.status.go.read() and button.text() == "Resume Queue":
             self.run()
     
     def run(self):

--- a/somatic/queue.py
+++ b/somatic/queue.py
@@ -296,6 +296,7 @@ class Worker(QtCore.QObject):
         item.finished.write(True)
 
     def execute_interrupt(self, item):
+        self.queue_status.go.write(False)
         if g.slack_enabled.read():
             message = ':octagonal_sign: Interrupted - {0}\n{1}\nUse `run` command to continue'.format(item.description, item.message)
             g.slack_control.read().send_message(message)
@@ -400,7 +401,7 @@ class Queue():
         item = self.items[self.index.read()]
         item.status = 'RUNNING'
         if isinstance(item, Interrupt):
-            self.status.go.write(False)
+            # This needs to run on the main thread to avoid Seg Fault
             if item.message.strip():
                 msg = QtWidgets.QMessageBox(QtWidgets.QMessageBox.NoIcon, "Interrupt", item.message, QtWidgets.QMessageBox.Ok, parent=self.gui.parent_widget)
                 msg.setModal(False)


### PR DESCRIPTION
Closes #238 

Okay, This now works _largely_ how I expect it:

When an interrupt is run by the queue:

- The flag to continue is set to False
- If a non-whitespace message was given, a dialog pops up
    - This dialog is _not_ modal, meaning that it does not prevent interracting with the main window
    - It is simply an (optional) message that users can invoke to provide context as to why the queue was stopped
    - The queue may be continued, even without dismissing the dialog (this choice was made to make using slack to continue the queue just work without modification, also because I want users to be able to edit the queue/motor positions without removing the reminder of what they need to do before continuing)

I also had a bit of a cleanup of related, but unused classes in project_widgets.