### PR TITLE
Add constant resolver order finder

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,5 @@ pyqtgraph
 pyserial
 slackclient
 slacker
+sympy
 tidy_headers>=1.0.0

--- a/somatic/acquisition.py
+++ b/somatic/acquisition.py
@@ -38,6 +38,8 @@ all_hardwares = opas.hardwares + spectrometers.hardwares + delays.hardwares + fi
 
 import devices.devices as devices
 
+from . import constant_resolver
+
 
 ### define ####################################################################
 
@@ -241,7 +243,11 @@ class Worker(QtCore.QObject):
                 passed_args = axis.hardware_dict[key][2]
                 destinations = Destinations(arr, axis.units, hardware, method, passed_args)
                 destinations_list.append(destinations)
-        for constant in constants:  # must follow axes
+        constant_dict = {c.name: c for c in constants}
+        for constant in constant_resolver.const_order(
+            **{c.name: c.expression for c in constants}
+        ):  # must follow axes
+            constant = constant_dict[constant]
             if constant.static:
                 pass
             else:

--- a/somatic/constant_resolver.py
+++ b/somatic/constant_resolver.py
@@ -1,0 +1,16 @@
+import sympy
+
+def const_order(**expressions):
+    expressions = {sympy.Symbol(k): sympy.sympify(v) for k,v in expressions.items()}
+    while expressions:
+        cycle = True
+        for symb,expr in list(expressions.items()):
+            if all(x.is_constant() or x not in expressions for x in expr.atoms()):
+                yield str(symb)
+                expressions.pop(symb)
+                cycle=False
+                break
+        if cycle:
+            raise ValueError("Cycle detected in set of expressions")
+
+


### PR DESCRIPTION
Closes #256 

This deterministically finds an appropriate order to resolve constant expressions.
Without this code, unexpected behavior can result if constants are "out of order"

For instance:

With an axis of `w1`, scanning
Constants:
```
wm=w2
w2=w1
```

With this code, it will see that `wm` is dependent on `w2`, and resolve `w2` first
Without this code, it will attempt to resolve `wm` first, and the result, unexpectedly,
is that wm stays (truly) constant at whatever `w2` _was before_ the scan.

Similar errors are possible, especially if a constant is remembered out of it's "natural" order or axes are changed, but relationships are intended to stay the same.

The resolver is a small function that is intended to be reusable as PyCMDS (and future acquisition software) evolve.
Right now it expects an expression that is `<variable>=<expression` where variable is the thing being solved. In the future it is possible that this will be relaxed to any equation with a single unknown being the condition. That will incur other api changes (e.g. cannot use **kwargs, return value may need to be changed), however it may also open up ways to define axes more naturally with expressions that equate to an array, eliminating the need for things like fake axes. I have some ideas in these areas, but going to table them for the time being, as they are not fleshed out.