### PR TITLE
Lgtm alerts

### DIFF
--- a/pycmds/_pycmds.py
+++ b/pycmds/_pycmds.py
@@ -17,12 +17,6 @@ import pathlib
 #### import ###################################################################
 # BEWARE OF CHANGING ORDER OF IMPORTS!!!!!!!!!
 
-
-import copy
-import glob
-import inspect
-import subprocess
-
 from .project import project_globals as g
 
 g.app.write(app)
@@ -40,7 +34,6 @@ from .hardware.hardware import all_initialized
 import appdirs
 import toml
 
-import WrightTools as wt
 import yaqc
 
 

--- a/pycmds/devices/InGaAs_array/InGaAs.py
+++ b/pycmds/devices/InGaAs_array/InGaAs.py
@@ -251,7 +251,7 @@ class GUI(BaseGUI):
         self.hardware.update_ui.connect(self.update)
 
     def update(self):
-        if not self.hardware.data.read() == None:
+        if not self.hardware.data.read() is None:
             # plot
             xi = self.hardware.map.read()
             yi = self.hardware.data.read()[0]

--- a/pycmds/devices/InGaAs_array/InGaAs_test.py
+++ b/pycmds/devices/InGaAs_array/InGaAs_test.py
@@ -32,8 +32,6 @@ ser.close()
 
 # process-----------------------------------------------------------------------
 
-out = np.zeros(256)
-
 # remove 'ready' from end
 string = line[:512]
 

--- a/pycmds/devices/devices.py
+++ b/pycmds/devices/devices.py
@@ -465,8 +465,6 @@ class Driver(pc.Driver):
         while self.freerun.read() and not self.enqueued.read():
             self.measure()
             self.busy.write(False)
-        else:
-            print(" ".join([self.name, "exiting loop!"]))
 
     def measure(self):
         timer = wt.kit.Timer(verbose=False)

--- a/pycmds/hardware/filters/filters.py
+++ b/pycmds/hardware/filters/filters.py
@@ -6,8 +6,6 @@ import pathlib
 import toml
 import appdirs
 
-import WrightTools as wt
-
 import pycmds.project.project_globals as g
 import pycmds.project.widgets as pw
 import pycmds.project.classes as pc

--- a/pycmds/hardware/filters/homebuilt/homebuilt.py
+++ b/pycmds/hardware/filters/homebuilt/homebuilt.py
@@ -7,7 +7,6 @@ import time
 
 import numpy as np
 
-import pycmds.project.project_globals as g
 from hardware.filters.filters import Driver as BaseDriver
 from hardware.filters.filters import GUI as BaseGUI
 import pycmds.project.com_handler as com_handler

--- a/pycmds/hardware/opas/PoyntingCorrection/PoyntingCorrectionDevice.py
+++ b/pycmds/hardware/opas/PoyntingCorrection/PoyntingCorrectionDevice.py
@@ -62,7 +62,7 @@ class PoyntingCorrectionDevice(object):
         return [self.get_motor_position(s) for s in self.motor_names]
 
     def home(self, motor=None):
-        if motor == None:
+        if motor is None:
             for m in range(len(self.motor_names)):
                 self._home(m)
         elif isinstance(motor, str):
@@ -120,7 +120,7 @@ class PoyntingCorrectionDevice(object):
         self.get_motor_positions()
 
     def zero(self, motor=None):
-        if motor == None:
+        if motor is None:
             for m in range(len(self.motor_names)):
                 self._zero(m)
         elif isinstance(motor, str):

--- a/pycmds/hardware/spectrometers/MicroHR/MicroHR.py
+++ b/pycmds/hardware/spectrometers/MicroHR/MicroHR.py
@@ -4,7 +4,6 @@
 import time
 
 import pycmds.project.classes as pc
-import pycmds.project.project_globals as g
 from hardware.spectrometers.spectrometers import Driver as BaseDriver
 from hardware.spectrometers.spectrometers import GUI as BaseGUI
 

--- a/pycmds/project/com_handler.py
+++ b/pycmds/project/com_handler.py
@@ -42,7 +42,7 @@ class COM(QtCore.QMutex):
 
     def _read(self, size=None):
         if self.data == "pass":
-            if size == None:
+            if size is None:
                 size = 1
             return self.instrument.read(size)
         elif self.data == "ASCII":

--- a/pycmds/project/ini_handler.py
+++ b/pycmds/project/ini_handler.py
@@ -3,11 +3,8 @@
 
 import ast
 import configparser
-import os
 
 from PySide2 import QtCore
-
-import pycmds.project.project_globals as g
 
 
 ### ini class #################################################################

--- a/pycmds/project/project_globals.py
+++ b/pycmds/project/project_globals.py
@@ -1,4 +1,3 @@
-import sys
 import time
 
 from PySide2 import QtWidgets, QtCore

--- a/pycmds/project/slack/bots.py
+++ b/pycmds/project/slack/bots.py
@@ -35,7 +35,6 @@ class PyCMDS_bot(object):
             print("The default channel does not exist. Better fix that.")
             self.channel = None
         else:
-            pass
             # self.users.set_active()
             hello = []
             while hello == []:

--- a/pycmds/project/slack/bots.py
+++ b/pycmds/project/slack/bots.py
@@ -83,7 +83,7 @@ class PyCMDS_bot(object):
         file_paths: a list of the file paths of the files to attache.
         Returns a True if message post was successful, returns False otherwise.
         """
-        if channel == None:
+        if channel is None:
             channel = self.channel
         if self._check_channel(channel):
             channel_object = self.rtmbot.slack_client.server.channels.find(channel)
@@ -107,7 +107,7 @@ class PyCMDS_bot(object):
         """
         Uploads a file. Pretty self explanitory.
         """
-        if channel == None:
+        if channel is None:
             channel = self.channel
         if self._check_channel(channel):
             upload_ok = self.slacker.files.upload(

--- a/pycmds/project/slack/bots.py
+++ b/pycmds/project/slack/bots.py
@@ -1,14 +1,11 @@
 # Slack implementation for pyCMDS
 
-import os
 import sys
 import time
 
 import pathlib
 import appdirs
 import toml
-
-import pycmds.project.project_globals as g
 
 from slacker.__init__ import Slacker
 from .rtmbot import RtmBot

--- a/pycmds/project/slack/rtmbot.py
+++ b/pycmds/project/slack/rtmbot.py
@@ -5,7 +5,6 @@ import sys
 sys.dont_write_bytecode = True  # ??? - Blaise 2020-08-13
 
 import glob
-import os
 import sys
 import time
 import logging

--- a/pycmds/project/slack/rtmbot.py
+++ b/pycmds/project/slack/rtmbot.py
@@ -12,7 +12,6 @@ import logging
 from argparse import ArgumentParser
 
 from slackclient import SlackClient
-import pycmds.project.project_globals as g
 
 import appdirs
 import toml

--- a/pycmds/project/slack/rtmbot.py
+++ b/pycmds/project/slack/rtmbot.py
@@ -181,22 +181,3 @@ def parse_args():
     parser.add_argument("-c", "--config", help="Full path to config file.", metavar="path")
     return parser.parse_args()
 
-
-if False:  # __name__ == "__main__":
-    args = parse_args()
-    directory = os.path.dirname(sys.argv[0])
-    if not directory.startswith("/"):
-        directory = os.path.abspath("{}/{}".format(os.getcwd(), directory))
-
-    # config = yaml.load(file(args.config or 'rtmbot.conf', 'r'))
-    # bot = RtmBot(config["SLACK_TOKEN"])
-    site_plugins = []
-    files_currently_downloading = []
-    job_hash = {}
-
-    """if config.has_key("DAEMON"):
-        if config["DAEMON"]:
-            import daemon
-            with daemon.DaemonContext():
-                main_loop()"""
-    main_loop()

--- a/pycmds/project/slack/rtmbot.py
+++ b/pycmds/project/slack/rtmbot.py
@@ -156,7 +156,6 @@ class Job(object):
         if self.lastrun + self.interval < time.time():
             self.function()
             self.lastrun = time.time()
-            pass
 
 
 class UnknownChannel(Exception):

--- a/pycmds/project/widgets.py
+++ b/pycmds/project/widgets.py
@@ -242,7 +242,7 @@ class InputTable(QtWidgets.QWidget):
         global_object.give_control(control)
         layout.addWidget(control)
         # units combobox
-        if not global_object.units_kind == None:
+        if not global_object.units_kind is None:
             control.setMinimumWidth(self.width_input - 55)
             control.setMaximumWidth(self.width_input - 55)
             units = QtWidgets.QComboBox()

--- a/pycmds/somatic/acquisition.py
+++ b/pycmds/somatic/acquisition.py
@@ -15,8 +15,6 @@ import pathlib
 import time
 import traceback
 
-import configparser
-
 import appdirs
 import toml
 import numpy as np

--- a/pycmds/somatic/acquisition.py
+++ b/pycmds/somatic/acquisition.py
@@ -29,8 +29,6 @@ import WrightTools as wt
 
 import pycmds.project.project_globals as g
 
-app = g.app.read()
-
 import pycmds.hardware.spectrometers.spectrometers as spectrometers
 import pycmds.hardware.delays.delays as delays
 import pycmds.hardware.opas.opas as opas
@@ -45,10 +43,6 @@ from . import constant_resolver
 
 ### define ####################################################################
 
-
-app = g.app.read()
-
-somatic_folder = os.path.dirname(__file__)
 
 
 __here__ = pathlib.Path(__file__).parent

--- a/pycmds/somatic/modules/home.py
+++ b/pycmds/somatic/modules/home.py
@@ -2,7 +2,6 @@
 
 import WrightTools as wt
 
-import pycmds.project.project_globals as g
 import pycmds.project.classes as pc
 import pycmds.project.widgets as pw
 import somatic.acquisition as acquisition

--- a/pycmds/somatic/modules/motortune.py
+++ b/pycmds/somatic/modules/motortune.py
@@ -1,7 +1,6 @@
 ### import ####################################################################
 
 
-import os
 import pathlib
 
 import numpy as np
@@ -12,7 +11,6 @@ matplotlib.pyplot.ioff()
 
 import WrightTools as wt
 
-import pycmds.project.project_globals as g
 import pycmds.project.classes as pc
 import pycmds.project.widgets as pw
 import somatic.acquisition as acquisition

--- a/pycmds/somatic/modules/scan.py
+++ b/pycmds/somatic/modules/scan.py
@@ -1,10 +1,6 @@
 ### import ####################################################################
 
-import os
 import pathlib
-
-import appdirs
-import toml
 
 import numpy as np
 
@@ -19,7 +15,6 @@ import pycmds.project.project_globals as g
 import pycmds.project.classes as pc
 import pycmds.project.widgets as pw
 import pycmds.somatic.acquisition as acquisition
-import pycmds.project.ini_handler as ini_handler
 
 import pycmds.hardware.spectrometers.spectrometers as spectrometers
 import pycmds.hardware.delays.delays as delays

--- a/pycmds/somatic/queue.py
+++ b/pycmds/somatic/queue.py
@@ -1107,7 +1107,6 @@ class GUI(QtCore.QObject):
             index = row
         else:
             index = row.toInt()[0]  # given as QVariant
-        new_index = new_index
         self.queue.change_index(index, new_index)
 
     def on_load_aqn(self):

--- a/pycmds/somatic/queue.py
+++ b/pycmds/somatic/queue.py
@@ -1386,7 +1386,7 @@ class GUI(QtCore.QObject):
             if not item.status == "ENQUEUED":
                 button.setDisabled(True)
             # load
-            button = self.add_button_to_table(i, 7, "LOAD", "go", self.on_load_item)
+            self.add_button_to_table(i, 7, "LOAD", "go", self.on_load_item)
 
     def update_type(self):
         for frame in self.type_frames.values():

--- a/pycmds/somatic/queue.py
+++ b/pycmds/somatic/queue.py
@@ -10,8 +10,6 @@ import dateutil
 import collections
 import pathlib
 
-import configparser as configparser
-
 from PySide2 import QtCore, QtWidgets
 
 import appdirs
@@ -250,13 +248,13 @@ class Worker(QtCore.QObject):
         tz = dateutil.tz.tzlocal()
         now = datetime.datetime.now(tz)
         if item.operation == "For":
-            h, m, s = [float(s) if s is not "" else 0.0 for s in item.amount.split(":")]
+            h, m, s = [float(s) if s != "" else 0.0 for s in item.amount.split(":")]
             total_seconds = 3600.0 * h + 60.0 * m + s
             stop_time = now + datetime.timedelta(0, total_seconds)
         elif item.operation == "Until":
             inputs = {}
             inputs["hour"], inputs["minute"], s = [
-                int(s) if s is not "" else 0 for s in item.amount.split(":")
+                int(s) if s != "" else 0 for s in item.amount.split(":")
             ]
             stop_time = collections.OrderedDict()
             stop_time["seconds"] = s


### PR DESCRIPTION
A collection of the safer, trivial to fix alert fixes from LGTM (plus a few syntax warnings from `is not == ""` which is incorrect)

I was careful to test that PyCMDS still ran and could take a scan, though admittedly did not venture to make sure all code paths were accessed.

That said, all of the changes are pretty easy to tell that they are correct, in my opinion

I avoided messing with files I am touching in #278, largely avoided the opas folder (aside from the `is None`, which raises a warning in python these days)

I largely did not touch internal library imports, focusing on removing unused imports of stdlib and 3rd party packages, though the scattered importing of project globals where there was no need was addressed.

I did not address unused variables, as it takes more thought than I was willing to give to determine if there are side effects or the line should just be gone (or indeed if it is an error that it _is_ unused), that accounts for ~30 of the remaining LGTM warnings (we were at 106)